### PR TITLE
Update element props interface names

### DIFF
--- a/a.ts
+++ b/a.ts
@@ -2,29 +2,55 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * AProps are the props for the [`a`](https://developer.mozilla.org/docs/Web/HTML/Element/a) element.
+ * AElementProps are the props for the [`a`](https://developer.mozilla.org/docs/Web/HTML/Element/a) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/a>
  */
-export interface AProps extends GlobalAttributes {
-  /** @experimental */
+export interface AElementProps extends GlobalAttributes {
+  /**
+   * `attributionsrc` is an attribute of the [`a`](https://developer.mozilla.org/docs/Web/HTML/Element/a) element.
+   * @experimental
+   */
   attributionsrc?: string | undefined;
-  /** @deprecated */
+  /**
+   * `charset` is an attribute of the [`a`](https://developer.mozilla.org/docs/Web/HTML/Element/a) element.
+   * @deprecated
+   */
   charset?: string | undefined;
-  /** @deprecated */
+  /**
+   * `coords` is an attribute of the [`a`](https://developer.mozilla.org/docs/Web/HTML/Element/a) element.
+   * @deprecated
+   */
   coords?: string | undefined;
+  /** `download` is an attribute of the [`a`](https://developer.mozilla.org/docs/Web/HTML/Element/a) element. */
   download?: string | undefined;
+  /** `href` is an attribute of the [`a`](https://developer.mozilla.org/docs/Web/HTML/Element/a) element. */
   href?: string | undefined;
+  /** `hreflang` is an attribute of the [`a`](https://developer.mozilla.org/docs/Web/HTML/Element/a) element. */
   hreflang?: string | undefined;
-  /** @deprecated */
+  /**
+   * `name` is an attribute of the [`a`](https://developer.mozilla.org/docs/Web/HTML/Element/a) element.
+   * @deprecated
+   */
   name?: string | undefined;
+  /** `ping` is an attribute of the [`a`](https://developer.mozilla.org/docs/Web/HTML/Element/a) element. */
   ping?: string | undefined;
+  /** `referrerpolicy` is an attribute of the [`a`](https://developer.mozilla.org/docs/Web/HTML/Element/a) element. */
   referrerpolicy?: string | undefined;
+  /** `rel` is an attribute of the [`a`](https://developer.mozilla.org/docs/Web/HTML/Element/a) element. */
   rel?: string | undefined;
-  /** @deprecated */
+  /**
+   * `rev` is an attribute of the [`a`](https://developer.mozilla.org/docs/Web/HTML/Element/a) element.
+   * @deprecated
+   */
   rev?: string | undefined;
-  /** @deprecated */
+  /**
+   * `shape` is an attribute of the [`a`](https://developer.mozilla.org/docs/Web/HTML/Element/a) element.
+   * @deprecated
+   */
   shape?: string | undefined;
+  /** `target` is an attribute of the [`a`](https://developer.mozilla.org/docs/Web/HTML/Element/a) element. */
   target?: string | undefined;
+  /** `type` is an attribute of the [`a`](https://developer.mozilla.org/docs/Web/HTML/Element/a) element. */
   type?: string | undefined;
 }
 
@@ -32,6 +58,6 @@ export interface AProps extends GlobalAttributes {
  * a renders the [`a`](https://developer.mozilla.org/docs/Web/HTML/Element/a) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/a>
  */
-export function a(props?: AProps, ...children: string[]): string {
+export function a(props?: AElementProps, ...children: string[]): string {
   return renderElement("a", props as AnyProps, false, children);
 }

--- a/abbr.ts
+++ b/abbr.ts
@@ -2,9 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * AbbrElementProps are the props for the [`abbr`](https://developer.mozilla.org/docs/Web/HTML/Element/abbr) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/abbr>
+ */
+export type AbbrElementProps = GlobalAttributes;
+
+/**
  * abbr renders the [`abbr`](https://developer.mozilla.org/docs/Web/HTML/Element/abbr) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/abbr>
  */
-export function abbr(props?: GlobalAttributes, ...children: string[]): string {
+export function abbr(props?: AbbrElementProps, ...children: string[]): string {
   return renderElement("abbr", props as AnyProps, false, children);
 }

--- a/abbr.ts
+++ b/abbr.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * AbbrElementProps are the props for the [`abbr`](https://developer.mozilla.org/docs/Web/HTML/Element/abbr) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/abbr>
  */
-export type AbbrElementProps = GlobalAttributes;
+export interface AbbrElementProps extends GlobalAttributes {
+}
 
 /**
  * abbr renders the [`abbr`](https://developer.mozilla.org/docs/Web/HTML/Element/abbr) element.

--- a/acronym.ts
+++ b/acronym.ts
@@ -2,12 +2,19 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * AcronymElementProps are the props for the [`acronym`](https://developer.mozilla.org/docs/Web/HTML/Element/acronym) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/acronym>
+ * @deprecated
+ */
+export type AcronymElementProps = GlobalAttributes;
+
+/**
  * acronym renders the [`acronym`](https://developer.mozilla.org/docs/Web/HTML/Element/acronym) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/acronym>
  * @deprecated
  */
 export function acronym(
-  props?: GlobalAttributes,
+  props?: AcronymElementProps,
   ...children: string[]
 ): string {
   return renderElement("acronym", props as AnyProps, false, children);

--- a/acronym.ts
+++ b/acronym.ts
@@ -6,7 +6,8 @@ import { renderElement } from "./lib/mod.ts";
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/acronym>
  * @deprecated
  */
-export type AcronymElementProps = GlobalAttributes;
+export interface AcronymElementProps extends GlobalAttributes {
+}
 
 /**
  * acronym renders the [`acronym`](https://developer.mozilla.org/docs/Web/HTML/Element/acronym) element.

--- a/address.ts
+++ b/address.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * AddressElementProps are the props for the [`address`](https://developer.mozilla.org/docs/Web/HTML/Element/address) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/address>
  */
-export type AddressElementProps = GlobalAttributes;
+export interface AddressElementProps extends GlobalAttributes {
+}
 
 /**
  * address renders the [`address`](https://developer.mozilla.org/docs/Web/HTML/Element/address) element.

--- a/address.ts
+++ b/address.ts
@@ -2,11 +2,17 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * AddressElementProps are the props for the [`address`](https://developer.mozilla.org/docs/Web/HTML/Element/address) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/address>
+ */
+export type AddressElementProps = GlobalAttributes;
+
+/**
  * address renders the [`address`](https://developer.mozilla.org/docs/Web/HTML/Element/address) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/address>
  */
 export function address(
-  props?: GlobalAttributes,
+  props?: AddressElementProps,
   ...children: string[]
 ): string {
   return renderElement("address", props as AnyProps, false, children);

--- a/area.ts
+++ b/area.ts
@@ -2,22 +2,37 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * AreaProps are the props for the [`area`](https://developer.mozilla.org/docs/Web/HTML/Element/area) element.
+ * AreaElementProps are the props for the [`area`](https://developer.mozilla.org/docs/Web/HTML/Element/area) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/area>
  */
-export interface AreaProps extends GlobalAttributes {
+export interface AreaElementProps extends GlobalAttributes {
+  /** `alt` is an attribute of the [`area`](https://developer.mozilla.org/docs/Web/HTML/Element/area) element. */
   alt?: string | undefined;
+  /** `coords` is an attribute of the [`area`](https://developer.mozilla.org/docs/Web/HTML/Element/area) element. */
   coords?: string | undefined;
+  /** `download` is an attribute of the [`area`](https://developer.mozilla.org/docs/Web/HTML/Element/area) element. */
   download?: string | undefined;
+  /** `href` is an attribute of the [`area`](https://developer.mozilla.org/docs/Web/HTML/Element/area) element. */
   href?: string | undefined;
-  /** @deprecated */
+  /**
+   * `nohref` is an attribute of the [`area`](https://developer.mozilla.org/docs/Web/HTML/Element/area) element.
+   * @deprecated
+   */
   nohref?: string | undefined;
+  /** `ping` is an attribute of the [`area`](https://developer.mozilla.org/docs/Web/HTML/Element/area) element. */
   ping?: string | undefined;
+  /** `referrerpolicy` is an attribute of the [`area`](https://developer.mozilla.org/docs/Web/HTML/Element/area) element. */
   referrerpolicy?: string | undefined;
+  /** `rel` is an attribute of the [`area`](https://developer.mozilla.org/docs/Web/HTML/Element/area) element. */
   rel?: string | undefined;
+  /** `shape` is an attribute of the [`area`](https://developer.mozilla.org/docs/Web/HTML/Element/area) element. */
   shape?: string | undefined;
-  /** @deprecated */
+  /**
+   * `tabindex` is an attribute of the [`area`](https://developer.mozilla.org/docs/Web/HTML/Element/area) element.
+   * @deprecated
+   */
   tabindex?: string | undefined;
+  /** `target` is an attribute of the [`area`](https://developer.mozilla.org/docs/Web/HTML/Element/area) element. */
   target?: string | undefined;
 }
 
@@ -25,6 +40,6 @@ export interface AreaProps extends GlobalAttributes {
  * area renders the [`area`](https://developer.mozilla.org/docs/Web/HTML/Element/area) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/area>
  */
-export function area(props?: AreaProps): string {
+export function area(props?: AreaElementProps): string {
   return renderElement("area", props as AnyProps, true);
 }

--- a/article.ts
+++ b/article.ts
@@ -2,11 +2,17 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * ArticleElementProps are the props for the [`article`](https://developer.mozilla.org/docs/Web/HTML/Element/article) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/article>
+ */
+export type ArticleElementProps = GlobalAttributes;
+
+/**
  * article renders the [`article`](https://developer.mozilla.org/docs/Web/HTML/Element/article) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/article>
  */
 export function article(
-  props?: GlobalAttributes,
+  props?: ArticleElementProps,
   ...children: string[]
 ): string {
   return renderElement("article", props as AnyProps, false, children);

--- a/article.ts
+++ b/article.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * ArticleElementProps are the props for the [`article`](https://developer.mozilla.org/docs/Web/HTML/Element/article) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/article>
  */
-export type ArticleElementProps = GlobalAttributes;
+export interface ArticleElementProps extends GlobalAttributes {
+}
 
 /**
  * article renders the [`article`](https://developer.mozilla.org/docs/Web/HTML/Element/article) element.

--- a/aside.ts
+++ b/aside.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * AsideElementProps are the props for the [`aside`](https://developer.mozilla.org/docs/Web/HTML/Element/aside) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/aside>
  */
-export type AsideElementProps = GlobalAttributes;
+export interface AsideElementProps extends GlobalAttributes {
+}
 
 /**
  * aside renders the [`aside`](https://developer.mozilla.org/docs/Web/HTML/Element/aside) element.

--- a/aside.ts
+++ b/aside.ts
@@ -2,9 +2,18 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * AsideElementProps are the props for the [`aside`](https://developer.mozilla.org/docs/Web/HTML/Element/aside) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/aside>
+ */
+export type AsideElementProps = GlobalAttributes;
+
+/**
  * aside renders the [`aside`](https://developer.mozilla.org/docs/Web/HTML/Element/aside) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/aside>
  */
-export function aside(props?: GlobalAttributes, ...children: string[]): string {
+export function aside(
+  props?: AsideElementProps,
+  ...children: string[]
+): string {
   return renderElement("aside", props as AnyProps, false, children);
 }

--- a/audio.ts
+++ b/audio.ts
@@ -2,18 +2,27 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * AudioProps are the props for the [`audio`](https://developer.mozilla.org/docs/Web/HTML/Element/audio) element.
+ * AudioElementProps are the props for the [`audio`](https://developer.mozilla.org/docs/Web/HTML/Element/audio) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/audio>
  */
-export interface AudioProps extends GlobalAttributes {
+export interface AudioElementProps extends GlobalAttributes {
+  /** `autoplay` is an attribute of the [`audio`](https://developer.mozilla.org/docs/Web/HTML/Element/audio) element. */
   autoplay?: string | undefined;
+  /** `controls` is an attribute of the [`audio`](https://developer.mozilla.org/docs/Web/HTML/Element/audio) element. */
   controls?: string | undefined;
+  /** `controlslist` is an attribute of the [`audio`](https://developer.mozilla.org/docs/Web/HTML/Element/audio) element. */
   controlslist?: string | undefined;
+  /** `crossorigin` is an attribute of the [`audio`](https://developer.mozilla.org/docs/Web/HTML/Element/audio) element. */
   crossorigin?: string | undefined;
+  /** `disableremoteplayback` is an attribute of the [`audio`](https://developer.mozilla.org/docs/Web/HTML/Element/audio) element. */
   disableremoteplayback?: string | undefined;
+  /** `loop` is an attribute of the [`audio`](https://developer.mozilla.org/docs/Web/HTML/Element/audio) element. */
   loop?: string | undefined;
+  /** `muted` is an attribute of the [`audio`](https://developer.mozilla.org/docs/Web/HTML/Element/audio) element. */
   muted?: string | undefined;
+  /** `preload` is an attribute of the [`audio`](https://developer.mozilla.org/docs/Web/HTML/Element/audio) element. */
   preload?: string | undefined;
+  /** `src` is an attribute of the [`audio`](https://developer.mozilla.org/docs/Web/HTML/Element/audio) element. */
   src?: string | undefined;
 }
 
@@ -21,6 +30,9 @@ export interface AudioProps extends GlobalAttributes {
  * audio renders the [`audio`](https://developer.mozilla.org/docs/Web/HTML/Element/audio) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/audio>
  */
-export function audio(props?: AudioProps, ...children: string[]): string {
+export function audio(
+  props?: AudioElementProps,
+  ...children: string[]
+): string {
   return renderElement("audio", props as AnyProps, false, children);
 }

--- a/b.ts
+++ b/b.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * BElementProps are the props for the [`b`](https://developer.mozilla.org/docs/Web/HTML/Element/b) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/b>
  */
-export type BElementProps = GlobalAttributes;
+export interface BElementProps extends GlobalAttributes {
+}
 
 /**
  * b renders the [`b`](https://developer.mozilla.org/docs/Web/HTML/Element/b) element.

--- a/b.ts
+++ b/b.ts
@@ -2,9 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * BElementProps are the props for the [`b`](https://developer.mozilla.org/docs/Web/HTML/Element/b) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/b>
+ */
+export type BElementProps = GlobalAttributes;
+
+/**
  * b renders the [`b`](https://developer.mozilla.org/docs/Web/HTML/Element/b) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/b>
  */
-export function b(props?: GlobalAttributes, ...children: string[]): string {
+export function b(props?: BElementProps, ...children: string[]): string {
   return renderElement("b", props as AnyProps, false, children);
 }

--- a/base.ts
+++ b/base.ts
@@ -2,11 +2,13 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * BaseProps are the props for the [`base`](https://developer.mozilla.org/docs/Web/HTML/Element/base) element.
+ * BaseElementProps are the props for the [`base`](https://developer.mozilla.org/docs/Web/HTML/Element/base) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/base>
  */
-export interface BaseProps extends GlobalAttributes {
+export interface BaseElementProps extends GlobalAttributes {
+  /** `href` is an attribute of the [`base`](https://developer.mozilla.org/docs/Web/HTML/Element/base) element. */
   href?: string | undefined;
+  /** `target` is an attribute of the [`base`](https://developer.mozilla.org/docs/Web/HTML/Element/base) element. */
   target?: string | undefined;
 }
 
@@ -14,6 +16,6 @@ export interface BaseProps extends GlobalAttributes {
  * base renders the [`base`](https://developer.mozilla.org/docs/Web/HTML/Element/base) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/base>
  */
-export function base(props?: BaseProps): string {
+export function base(props?: BaseElementProps): string {
   return renderElement("base", props as AnyProps, true);
 }

--- a/bdi.ts
+++ b/bdi.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * BdiElementProps are the props for the [`bdi`](https://developer.mozilla.org/docs/Web/HTML/Element/bdi) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/bdi>
  */
-export type BdiElementProps = GlobalAttributes;
+export interface BdiElementProps extends GlobalAttributes {
+}
 
 /**
  * bdi renders the [`bdi`](https://developer.mozilla.org/docs/Web/HTML/Element/bdi) element.

--- a/bdi.ts
+++ b/bdi.ts
@@ -2,9 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * BdiElementProps are the props for the [`bdi`](https://developer.mozilla.org/docs/Web/HTML/Element/bdi) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/bdi>
+ */
+export type BdiElementProps = GlobalAttributes;
+
+/**
  * bdi renders the [`bdi`](https://developer.mozilla.org/docs/Web/HTML/Element/bdi) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/bdi>
  */
-export function bdi(props?: GlobalAttributes, ...children: string[]): string {
+export function bdi(props?: BdiElementProps, ...children: string[]): string {
   return renderElement("bdi", props as AnyProps, false, children);
 }

--- a/bdo.ts
+++ b/bdo.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * BdoElementProps are the props for the [`bdo`](https://developer.mozilla.org/docs/Web/HTML/Element/bdo) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/bdo>
  */
-export type BdoElementProps = GlobalAttributes;
+export interface BdoElementProps extends GlobalAttributes {
+}
 
 /**
  * bdo renders the [`bdo`](https://developer.mozilla.org/docs/Web/HTML/Element/bdo) element.

--- a/bdo.ts
+++ b/bdo.ts
@@ -2,9 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * BdoElementProps are the props for the [`bdo`](https://developer.mozilla.org/docs/Web/HTML/Element/bdo) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/bdo>
+ */
+export type BdoElementProps = GlobalAttributes;
+
+/**
  * bdo renders the [`bdo`](https://developer.mozilla.org/docs/Web/HTML/Element/bdo) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/bdo>
  */
-export function bdo(props?: GlobalAttributes, ...children: string[]): string {
+export function bdo(props?: BdoElementProps, ...children: string[]): string {
   return renderElement("bdo", props as AnyProps, false, children);
 }

--- a/big.ts
+++ b/big.ts
@@ -6,7 +6,8 @@ import { renderElement } from "./lib/mod.ts";
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/big>
  * @deprecated
  */
-export type BigElementProps = GlobalAttributes;
+export interface BigElementProps extends GlobalAttributes {
+}
 
 /**
  * big renders the [`big`](https://developer.mozilla.org/docs/Web/HTML/Element/big) element.

--- a/big.ts
+++ b/big.ts
@@ -2,10 +2,17 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * BigElementProps are the props for the [`big`](https://developer.mozilla.org/docs/Web/HTML/Element/big) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/big>
+ * @deprecated
+ */
+export type BigElementProps = GlobalAttributes;
+
+/**
  * big renders the [`big`](https://developer.mozilla.org/docs/Web/HTML/Element/big) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/big>
  * @deprecated
  */
-export function big(props?: GlobalAttributes, ...children: string[]): string {
+export function big(props?: BigElementProps, ...children: string[]): string {
   return renderElement("big", props as AnyProps, false, children);
 }

--- a/blockquote.ts
+++ b/blockquote.ts
@@ -2,10 +2,11 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * BlockquoteProps are the props for the [`blockquote`](https://developer.mozilla.org/docs/Web/HTML/Element/blockquote) element.
+ * BlockquoteElementProps are the props for the [`blockquote`](https://developer.mozilla.org/docs/Web/HTML/Element/blockquote) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/blockquote>
  */
-export interface BlockquoteProps extends GlobalAttributes {
+export interface BlockquoteElementProps extends GlobalAttributes {
+  /** `cite` is an attribute of the [`blockquote`](https://developer.mozilla.org/docs/Web/HTML/Element/blockquote) element. */
   cite?: string | undefined;
 }
 
@@ -14,7 +15,7 @@ export interface BlockquoteProps extends GlobalAttributes {
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/blockquote>
  */
 export function blockquote(
-  props?: BlockquoteProps,
+  props?: BlockquoteElementProps,
   ...children: string[]
 ): string {
   return renderElement("blockquote", props as AnyProps, false, children);

--- a/body.ts
+++ b/body.ts
@@ -2,29 +2,59 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * BodyProps are the props for the [`body`](https://developer.mozilla.org/docs/Web/HTML/Element/body) element.
+ * BodyElementProps are the props for the [`body`](https://developer.mozilla.org/docs/Web/HTML/Element/body) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/body>
  */
-export interface BodyProps extends GlobalAttributes {
-  /** @deprecated */
+export interface BodyElementProps extends GlobalAttributes {
+  /**
+   * `alink` is an attribute of the [`body`](https://developer.mozilla.org/docs/Web/HTML/Element/body) element.
+   * @deprecated
+   */
   alink?: string | undefined;
-  /** @deprecated */
+  /**
+   * `background` is an attribute of the [`body`](https://developer.mozilla.org/docs/Web/HTML/Element/body) element.
+   * @deprecated
+   */
   background?: string | undefined;
-  /** @deprecated */
+  /**
+   * `bgcolor` is an attribute of the [`body`](https://developer.mozilla.org/docs/Web/HTML/Element/body) element.
+   * @deprecated
+   */
   bgcolor?: string | undefined;
-  /** @deprecated */
+  /**
+   * `bottommargin` is an attribute of the [`body`](https://developer.mozilla.org/docs/Web/HTML/Element/body) element.
+   * @deprecated
+   */
   bottommargin?: string | undefined;
-  /** @deprecated */
+  /**
+   * `leftmargin` is an attribute of the [`body`](https://developer.mozilla.org/docs/Web/HTML/Element/body) element.
+   * @deprecated
+   */
   leftmargin?: string | undefined;
-  /** @deprecated */
+  /**
+   * `link` is an attribute of the [`body`](https://developer.mozilla.org/docs/Web/HTML/Element/body) element.
+   * @deprecated
+   */
   link?: string | undefined;
-  /** @deprecated */
+  /**
+   * `rightmargin` is an attribute of the [`body`](https://developer.mozilla.org/docs/Web/HTML/Element/body) element.
+   * @deprecated
+   */
   rightmargin?: string | undefined;
-  /** @deprecated */
+  /**
+   * `text` is an attribute of the [`body`](https://developer.mozilla.org/docs/Web/HTML/Element/body) element.
+   * @deprecated
+   */
   text?: string | undefined;
-  /** @deprecated */
+  /**
+   * `topmargin` is an attribute of the [`body`](https://developer.mozilla.org/docs/Web/HTML/Element/body) element.
+   * @deprecated
+   */
   topmargin?: string | undefined;
-  /** @deprecated */
+  /**
+   * `vlink` is an attribute of the [`body`](https://developer.mozilla.org/docs/Web/HTML/Element/body) element.
+   * @deprecated
+   */
   vlink?: string | undefined;
 }
 
@@ -32,6 +62,6 @@ export interface BodyProps extends GlobalAttributes {
  * body renders the [`body`](https://developer.mozilla.org/docs/Web/HTML/Element/body) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/body>
  */
-export function body(props?: BodyProps, ...children: string[]): string {
+export function body(props?: BodyElementProps, ...children: string[]): string {
   return renderElement("body", props as AnyProps, false, children);
 }

--- a/br.ts
+++ b/br.ts
@@ -2,11 +2,14 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * BrProps are the props for the [`br`](https://developer.mozilla.org/docs/Web/HTML/Element/br) element.
+ * BrElementProps are the props for the [`br`](https://developer.mozilla.org/docs/Web/HTML/Element/br) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/br>
  */
-export interface BrProps extends GlobalAttributes {
-  /** @deprecated */
+export interface BrElementProps extends GlobalAttributes {
+  /**
+   * `clear` is an attribute of the [`br`](https://developer.mozilla.org/docs/Web/HTML/Element/br) element.
+   * @deprecated
+   */
   clear?: string | undefined;
 }
 
@@ -14,6 +17,6 @@ export interface BrProps extends GlobalAttributes {
  * br renders the [`br`](https://developer.mozilla.org/docs/Web/HTML/Element/br) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/br>
  */
-export function br(props?: BrProps): string {
+export function br(props?: BrElementProps): string {
   return renderElement("br", props as AnyProps, true);
 }

--- a/button.ts
+++ b/button.ts
@@ -2,21 +2,33 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * ButtonProps are the props for the [`button`](https://developer.mozilla.org/docs/Web/HTML/Element/button) element.
+ * ButtonElementProps are the props for the [`button`](https://developer.mozilla.org/docs/Web/HTML/Element/button) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/button>
  */
-export interface ButtonProps extends GlobalAttributes {
+export interface ButtonElementProps extends GlobalAttributes {
+  /** `disabled` is an attribute of the [`button`](https://developer.mozilla.org/docs/Web/HTML/Element/button) element. */
   disabled?: string | undefined;
+  /** `form` is an attribute of the [`button`](https://developer.mozilla.org/docs/Web/HTML/Element/button) element. */
   form?: string | undefined;
+  /** `formaction` is an attribute of the [`button`](https://developer.mozilla.org/docs/Web/HTML/Element/button) element. */
   formaction?: string | undefined;
+  /** `formenctype` is an attribute of the [`button`](https://developer.mozilla.org/docs/Web/HTML/Element/button) element. */
   formenctype?: string | undefined;
+  /** `formmethod` is an attribute of the [`button`](https://developer.mozilla.org/docs/Web/HTML/Element/button) element. */
   formmethod?: string | undefined;
+  /** `formnovalidate` is an attribute of the [`button`](https://developer.mozilla.org/docs/Web/HTML/Element/button) element. */
   formnovalidate?: string | undefined;
+  /** `formtarget` is an attribute of the [`button`](https://developer.mozilla.org/docs/Web/HTML/Element/button) element. */
   formtarget?: string | undefined;
+  /** `name` is an attribute of the [`button`](https://developer.mozilla.org/docs/Web/HTML/Element/button) element. */
   name?: string | undefined;
+  /** `popovertarget` is an attribute of the [`button`](https://developer.mozilla.org/docs/Web/HTML/Element/button) element. */
   popovertarget?: string | undefined;
+  /** `popovertargetaction` is an attribute of the [`button`](https://developer.mozilla.org/docs/Web/HTML/Element/button) element. */
   popovertargetaction?: string | undefined;
+  /** `type` is an attribute of the [`button`](https://developer.mozilla.org/docs/Web/HTML/Element/button) element. */
   type?: string | undefined;
+  /** `value` is an attribute of the [`button`](https://developer.mozilla.org/docs/Web/HTML/Element/button) element. */
   value?: string | undefined;
 }
 
@@ -24,6 +36,9 @@ export interface ButtonProps extends GlobalAttributes {
  * button renders the [`button`](https://developer.mozilla.org/docs/Web/HTML/Element/button) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/button>
  */
-export function button(props?: ButtonProps, ...children: string[]): string {
+export function button(
+  props?: ButtonElementProps,
+  ...children: string[]
+): string {
   return renderElement("button", props as AnyProps, false, children);
 }

--- a/canvas.ts
+++ b/canvas.ts
@@ -2,13 +2,18 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * CanvasProps are the props for the [`canvas`](https://developer.mozilla.org/docs/Web/HTML/Element/canvas) element.
+ * CanvasElementProps are the props for the [`canvas`](https://developer.mozilla.org/docs/Web/HTML/Element/canvas) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/canvas>
  */
-export interface CanvasProps extends GlobalAttributes {
+export interface CanvasElementProps extends GlobalAttributes {
+  /** `height` is an attribute of the [`canvas`](https://developer.mozilla.org/docs/Web/HTML/Element/canvas) element. */
   height?: string | undefined;
-  /** @deprecated */
+  /**
+   * `moz-opaque` is an attribute of the [`canvas`](https://developer.mozilla.org/docs/Web/HTML/Element/canvas) element.
+   * @deprecated
+   */
   "moz-opaque"?: string | undefined;
+  /** `width` is an attribute of the [`canvas`](https://developer.mozilla.org/docs/Web/HTML/Element/canvas) element. */
   width?: string | undefined;
 }
 
@@ -16,6 +21,9 @@ export interface CanvasProps extends GlobalAttributes {
  * canvas renders the [`canvas`](https://developer.mozilla.org/docs/Web/HTML/Element/canvas) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/canvas>
  */
-export function canvas(props?: CanvasProps, ...children: string[]): string {
+export function canvas(
+  props?: CanvasElementProps,
+  ...children: string[]
+): string {
   return renderElement("canvas", props as AnyProps, false, children);
 }

--- a/caption.ts
+++ b/caption.ts
@@ -2,11 +2,14 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * CaptionProps are the props for the [`caption`](https://developer.mozilla.org/docs/Web/HTML/Element/caption) element.
+ * CaptionElementProps are the props for the [`caption`](https://developer.mozilla.org/docs/Web/HTML/Element/caption) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/caption>
  */
-export interface CaptionProps extends GlobalAttributes {
-  /** @deprecated */
+export interface CaptionElementProps extends GlobalAttributes {
+  /**
+   * `align` is an attribute of the [`caption`](https://developer.mozilla.org/docs/Web/HTML/Element/caption) element.
+   * @deprecated
+   */
   align?: string | undefined;
 }
 
@@ -14,6 +17,9 @@ export interface CaptionProps extends GlobalAttributes {
  * caption renders the [`caption`](https://developer.mozilla.org/docs/Web/HTML/Element/caption) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/caption>
  */
-export function caption(props?: CaptionProps, ...children: string[]): string {
+export function caption(
+  props?: CaptionElementProps,
+  ...children: string[]
+): string {
   return renderElement("caption", props as AnyProps, false, children);
 }

--- a/center.ts
+++ b/center.ts
@@ -6,7 +6,8 @@ import { renderElement } from "./lib/mod.ts";
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/center>
  * @deprecated
  */
-export type CenterElementProps = GlobalAttributes;
+export interface CenterElementProps extends GlobalAttributes {
+}
 
 /**
  * center renders the [`center`](https://developer.mozilla.org/docs/Web/HTML/Element/center) element.

--- a/center.ts
+++ b/center.ts
@@ -2,12 +2,19 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * CenterElementProps are the props for the [`center`](https://developer.mozilla.org/docs/Web/HTML/Element/center) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/center>
+ * @deprecated
+ */
+export type CenterElementProps = GlobalAttributes;
+
+/**
  * center renders the [`center`](https://developer.mozilla.org/docs/Web/HTML/Element/center) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/center>
  * @deprecated
  */
 export function center(
-  props?: GlobalAttributes,
+  props?: CenterElementProps,
   ...children: string[]
 ): string {
   return renderElement("center", props as AnyProps, false, children);

--- a/cite.ts
+++ b/cite.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * CiteElementProps are the props for the [`cite`](https://developer.mozilla.org/docs/Web/HTML/Element/cite) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/cite>
  */
-export type CiteElementProps = GlobalAttributes;
+export interface CiteElementProps extends GlobalAttributes {
+}
 
 /**
  * cite renders the [`cite`](https://developer.mozilla.org/docs/Web/HTML/Element/cite) element.

--- a/cite.ts
+++ b/cite.ts
@@ -2,9 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * CiteElementProps are the props for the [`cite`](https://developer.mozilla.org/docs/Web/HTML/Element/cite) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/cite>
+ */
+export type CiteElementProps = GlobalAttributes;
+
+/**
  * cite renders the [`cite`](https://developer.mozilla.org/docs/Web/HTML/Element/cite) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/cite>
  */
-export function cite(props?: GlobalAttributes, ...children: string[]): string {
+export function cite(props?: CiteElementProps, ...children: string[]): string {
   return renderElement("cite", props as AnyProps, false, children);
 }

--- a/cli/codegen.ts
+++ b/cli/codegen.ts
@@ -136,48 +136,33 @@ if (import.meta.main) {
     });
 
     // Add an interface for the props.
-    if (descriptor.attrs.length > 0) {
-      sourceFile.addInterface({
-        name: descriptor.propsInterfaceName,
-        isExported: true,
-        extends: ["GlobalAttributes"],
-        docs: toDocs({
-          description:
-            `${descriptor.propsInterfaceName} are the props for the [\`${descriptor.tag}\`](${descriptor.see}) element.`,
-          see: descriptor.see,
-          isDeprecated: descriptor.isDeprecated,
-          isExperimental: descriptor.isExperimental,
-        }),
-        properties: descriptor.attrs.map((attr) => {
-          return {
-            name: attr.includes("-") ? `'${attr}'` : attr,
-            hasQuestionToken: true,
-            type: "string | undefined",
-            docs: toDocs({
-              description:
-                `\`${attr}\` is an attribute of the [\`${descriptor.tag}\`](${descriptor.see}) element.`,
-              isExperimental: bcd.html.elements[descriptor.tag][attr].__compat
-                ?.status?.experimental,
-              isDeprecated: bcd.html.elements[descriptor.tag][attr].__compat
-                ?.status?.deprecated,
-            }),
-          };
-        }),
-      });
-    } else {
-      sourceFile.addInterface({
-        name: descriptor.propsInterfaceName,
-        isExported: true,
-        extends: ["GlobalAttributes"],
-        docs: toDocs({
-          description:
-            `${descriptor.propsInterfaceName} are the props for the [\`${descriptor.tag}\`](${descriptor.see}) element.`,
-          see: descriptor.see,
-          isDeprecated: descriptor.isDeprecated,
-          isExperimental: descriptor.isExperimental,
-        }),
-      });
-    }
+    sourceFile.addInterface({
+      name: descriptor.propsInterfaceName,
+      isExported: true,
+      extends: ["GlobalAttributes"],
+      docs: toDocs({
+        description:
+          `${descriptor.propsInterfaceName} are the props for the [\`${descriptor.tag}\`](${descriptor.see}) element.`,
+        see: descriptor.see,
+        isDeprecated: descriptor.isDeprecated,
+        isExperimental: descriptor.isExperimental,
+      }),
+      properties: descriptor.attrs.map((attr) => {
+        return {
+          name: attr.includes("-") ? `'${attr}'` : attr,
+          hasQuestionToken: true,
+          type: "string | undefined",
+          docs: toDocs({
+            description:
+              `\`${attr}\` is an attribute of the [\`${descriptor.tag}\`](${descriptor.see}) element.`,
+            isExperimental: bcd.html.elements[descriptor.tag][attr].__compat
+              ?.status?.experimental,
+            isDeprecated: bcd.html.elements[descriptor.tag][attr].__compat
+              ?.status?.deprecated,
+          }),
+        };
+      }),
+    });
 
     // Add the element render function.
     sourceFile.addFunction({

--- a/cli/codegen.ts
+++ b/cli/codegen.ts
@@ -165,10 +165,10 @@ if (import.meta.main) {
         }),
       });
     } else {
-      sourceFile.addTypeAlias({
+      sourceFile.addInterface({
         name: descriptor.propsInterfaceName,
         isExported: true,
-        type: "GlobalAttributes",
+        extends: ["GlobalAttributes"],
         docs: toDocs({
           description:
             `${descriptor.propsInterfaceName} are the props for the [\`${descriptor.tag}\`](${descriptor.see}) element.`,

--- a/cli/codegen.ts
+++ b/cli/codegen.ts
@@ -154,12 +154,27 @@ if (import.meta.main) {
             hasQuestionToken: true,
             type: "string | undefined",
             docs: toDocs({
+              description:
+                `\`${attr}\` is an attribute of the [\`${descriptor.tag}\`](${descriptor.see}) element.`,
               isExperimental: bcd.html.elements[descriptor.tag][attr].__compat
                 ?.status?.experimental,
               isDeprecated: bcd.html.elements[descriptor.tag][attr].__compat
                 ?.status?.deprecated,
             }),
           };
+        }),
+      });
+    } else {
+      sourceFile.addTypeAlias({
+        name: descriptor.propsInterfaceName,
+        isExported: true,
+        type: "GlobalAttributes",
+        docs: toDocs({
+          description:
+            `${descriptor.propsInterfaceName} are the props for the [\`${descriptor.tag}\`](${descriptor.see}) element.`,
+          see: descriptor.see,
+          isDeprecated: descriptor.isDeprecated,
+          isExperimental: descriptor.isExperimental,
         }),
       });
     }
@@ -260,9 +275,7 @@ export function getDescriptors(): Descriptor[] {
     descriptors.push({
       tag,
       functionName: toFunctionName(tag),
-      propsInterfaceName: attrs.length === 0
-        ? "GlobalAttributes"
-        : `${capitalize(tag)}Props`,
+      propsInterfaceName: `${capitalize(tag)}ElementProps`,
       isVoid: isVoid(tag),
       attrs,
       see: bcd.html.elements[tag].__compat?.mdn_url,

--- a/code.ts
+++ b/code.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * CodeElementProps are the props for the [`code`](https://developer.mozilla.org/docs/Web/HTML/Element/code) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/code>
  */
-export type CodeElementProps = GlobalAttributes;
+export interface CodeElementProps extends GlobalAttributes {
+}
 
 /**
  * code renders the [`code`](https://developer.mozilla.org/docs/Web/HTML/Element/code) element.

--- a/code.ts
+++ b/code.ts
@@ -2,9 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * CodeElementProps are the props for the [`code`](https://developer.mozilla.org/docs/Web/HTML/Element/code) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/code>
+ */
+export type CodeElementProps = GlobalAttributes;
+
+/**
  * code renders the [`code`](https://developer.mozilla.org/docs/Web/HTML/Element/code) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/code>
  */
-export function code(props?: GlobalAttributes, ...children: string[]): string {
+export function code(props?: CodeElementProps, ...children: string[]): string {
   return renderElement("code", props as AnyProps, false, children);
 }

--- a/col.ts
+++ b/col.ts
@@ -2,20 +2,36 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * ColProps are the props for the [`col`](https://developer.mozilla.org/docs/Web/HTML/Element/col) element.
+ * ColElementProps are the props for the [`col`](https://developer.mozilla.org/docs/Web/HTML/Element/col) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/col>
  */
-export interface ColProps extends GlobalAttributes {
-  /** @deprecated */
+export interface ColElementProps extends GlobalAttributes {
+  /**
+   * `align` is an attribute of the [`col`](https://developer.mozilla.org/docs/Web/HTML/Element/col) element.
+   * @deprecated
+   */
   align?: string | undefined;
-  /** @deprecated */
+  /**
+   * `char` is an attribute of the [`col`](https://developer.mozilla.org/docs/Web/HTML/Element/col) element.
+   * @deprecated
+   */
   char?: string | undefined;
-  /** @deprecated */
+  /**
+   * `charoff` is an attribute of the [`col`](https://developer.mozilla.org/docs/Web/HTML/Element/col) element.
+   * @deprecated
+   */
   charoff?: string | undefined;
+  /** `span` is an attribute of the [`col`](https://developer.mozilla.org/docs/Web/HTML/Element/col) element. */
   span?: string | undefined;
-  /** @deprecated */
+  /**
+   * `valign` is an attribute of the [`col`](https://developer.mozilla.org/docs/Web/HTML/Element/col) element.
+   * @deprecated
+   */
   valign?: string | undefined;
-  /** @deprecated */
+  /**
+   * `width` is an attribute of the [`col`](https://developer.mozilla.org/docs/Web/HTML/Element/col) element.
+   * @deprecated
+   */
   width?: string | undefined;
 }
 
@@ -23,6 +39,6 @@ export interface ColProps extends GlobalAttributes {
  * col renders the [`col`](https://developer.mozilla.org/docs/Web/HTML/Element/col) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/col>
  */
-export function col(props?: ColProps): string {
+export function col(props?: ColElementProps): string {
   return renderElement("col", props as AnyProps, true);
 }

--- a/colgroup.ts
+++ b/colgroup.ts
@@ -2,20 +2,36 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * ColgroupProps are the props for the [`colgroup`](https://developer.mozilla.org/docs/Web/HTML/Element/colgroup) element.
+ * ColgroupElementProps are the props for the [`colgroup`](https://developer.mozilla.org/docs/Web/HTML/Element/colgroup) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/colgroup>
  */
-export interface ColgroupProps extends GlobalAttributes {
-  /** @deprecated */
+export interface ColgroupElementProps extends GlobalAttributes {
+  /**
+   * `align` is an attribute of the [`colgroup`](https://developer.mozilla.org/docs/Web/HTML/Element/colgroup) element.
+   * @deprecated
+   */
   align?: string | undefined;
-  /** @deprecated */
+  /**
+   * `char` is an attribute of the [`colgroup`](https://developer.mozilla.org/docs/Web/HTML/Element/colgroup) element.
+   * @deprecated
+   */
   char?: string | undefined;
-  /** @deprecated */
+  /**
+   * `charoff` is an attribute of the [`colgroup`](https://developer.mozilla.org/docs/Web/HTML/Element/colgroup) element.
+   * @deprecated
+   */
   charoff?: string | undefined;
+  /** `span` is an attribute of the [`colgroup`](https://developer.mozilla.org/docs/Web/HTML/Element/colgroup) element. */
   span?: string | undefined;
-  /** @deprecated */
+  /**
+   * `valign` is an attribute of the [`colgroup`](https://developer.mozilla.org/docs/Web/HTML/Element/colgroup) element.
+   * @deprecated
+   */
   valign?: string | undefined;
-  /** @deprecated */
+  /**
+   * `width` is an attribute of the [`colgroup`](https://developer.mozilla.org/docs/Web/HTML/Element/colgroup) element.
+   * @deprecated
+   */
   width?: string | undefined;
 }
 
@@ -23,6 +39,9 @@ export interface ColgroupProps extends GlobalAttributes {
  * colgroup renders the [`colgroup`](https://developer.mozilla.org/docs/Web/HTML/Element/colgroup) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/colgroup>
  */
-export function colgroup(props?: ColgroupProps, ...children: string[]): string {
+export function colgroup(
+  props?: ColgroupElementProps,
+  ...children: string[]
+): string {
   return renderElement("colgroup", props as AnyProps, false, children);
 }

--- a/data.ts
+++ b/data.ts
@@ -2,10 +2,11 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * DataProps are the props for the [`data`](https://developer.mozilla.org/docs/Web/HTML/Element/data) element.
+ * DataElementProps are the props for the [`data`](https://developer.mozilla.org/docs/Web/HTML/Element/data) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/data>
  */
-export interface DataProps extends GlobalAttributes {
+export interface DataElementProps extends GlobalAttributes {
+  /** `value` is an attribute of the [`data`](https://developer.mozilla.org/docs/Web/HTML/Element/data) element. */
   value?: string | undefined;
 }
 
@@ -13,6 +14,6 @@ export interface DataProps extends GlobalAttributes {
  * data renders the [`data`](https://developer.mozilla.org/docs/Web/HTML/Element/data) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/data>
  */
-export function data(props?: DataProps, ...children: string[]): string {
+export function data(props?: DataElementProps, ...children: string[]): string {
   return renderElement("data", props as AnyProps, false, children);
 }

--- a/datalist.ts
+++ b/datalist.ts
@@ -2,11 +2,17 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * DatalistElementProps are the props for the [`datalist`](https://developer.mozilla.org/docs/Web/HTML/Element/datalist) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/datalist>
+ */
+export type DatalistElementProps = GlobalAttributes;
+
+/**
  * datalist renders the [`datalist`](https://developer.mozilla.org/docs/Web/HTML/Element/datalist) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/datalist>
  */
 export function datalist(
-  props?: GlobalAttributes,
+  props?: DatalistElementProps,
   ...children: string[]
 ): string {
   return renderElement("datalist", props as AnyProps, false, children);

--- a/datalist.ts
+++ b/datalist.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * DatalistElementProps are the props for the [`datalist`](https://developer.mozilla.org/docs/Web/HTML/Element/datalist) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/datalist>
  */
-export type DatalistElementProps = GlobalAttributes;
+export interface DatalistElementProps extends GlobalAttributes {
+}
 
 /**
  * datalist renders the [`datalist`](https://developer.mozilla.org/docs/Web/HTML/Element/datalist) element.

--- a/dd.ts
+++ b/dd.ts
@@ -2,9 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * DdElementProps are the props for the [`dd`](https://developer.mozilla.org/docs/Web/HTML/Element/dd) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/dd>
+ */
+export type DdElementProps = GlobalAttributes;
+
+/**
  * dd renders the [`dd`](https://developer.mozilla.org/docs/Web/HTML/Element/dd) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/dd>
  */
-export function dd(props?: GlobalAttributes, ...children: string[]): string {
+export function dd(props?: DdElementProps, ...children: string[]): string {
   return renderElement("dd", props as AnyProps, false, children);
 }

--- a/dd.ts
+++ b/dd.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * DdElementProps are the props for the [`dd`](https://developer.mozilla.org/docs/Web/HTML/Element/dd) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/dd>
  */
-export type DdElementProps = GlobalAttributes;
+export interface DdElementProps extends GlobalAttributes {
+}
 
 /**
  * dd renders the [`dd`](https://developer.mozilla.org/docs/Web/HTML/Element/dd) element.

--- a/del.ts
+++ b/del.ts
@@ -2,11 +2,13 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * DelProps are the props for the [`del`](https://developer.mozilla.org/docs/Web/HTML/Element/del) element.
+ * DelElementProps are the props for the [`del`](https://developer.mozilla.org/docs/Web/HTML/Element/del) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/del>
  */
-export interface DelProps extends GlobalAttributes {
+export interface DelElementProps extends GlobalAttributes {
+  /** `cite` is an attribute of the [`del`](https://developer.mozilla.org/docs/Web/HTML/Element/del) element. */
   cite?: string | undefined;
+  /** `datetime` is an attribute of the [`del`](https://developer.mozilla.org/docs/Web/HTML/Element/del) element. */
   datetime?: string | undefined;
 }
 
@@ -14,6 +16,6 @@ export interface DelProps extends GlobalAttributes {
  * del renders the [`del`](https://developer.mozilla.org/docs/Web/HTML/Element/del) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/del>
  */
-export function del(props?: DelProps, ...children: string[]): string {
+export function del(props?: DelElementProps, ...children: string[]): string {
   return renderElement("del", props as AnyProps, false, children);
 }

--- a/details.ts
+++ b/details.ts
@@ -2,11 +2,13 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * DetailsProps are the props for the [`details`](https://developer.mozilla.org/docs/Web/HTML/Element/details) element.
+ * DetailsElementProps are the props for the [`details`](https://developer.mozilla.org/docs/Web/HTML/Element/details) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/details>
  */
-export interface DetailsProps extends GlobalAttributes {
+export interface DetailsElementProps extends GlobalAttributes {
+  /** `name` is an attribute of the [`details`](https://developer.mozilla.org/docs/Web/HTML/Element/details) element. */
   name?: string | undefined;
+  /** `open` is an attribute of the [`details`](https://developer.mozilla.org/docs/Web/HTML/Element/details) element. */
   open?: string | undefined;
 }
 
@@ -14,6 +16,9 @@ export interface DetailsProps extends GlobalAttributes {
  * details renders the [`details`](https://developer.mozilla.org/docs/Web/HTML/Element/details) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/details>
  */
-export function details(props?: DetailsProps, ...children: string[]): string {
+export function details(
+  props?: DetailsElementProps,
+  ...children: string[]
+): string {
   return renderElement("details", props as AnyProps, false, children);
 }

--- a/dfn.ts
+++ b/dfn.ts
@@ -2,9 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * DfnElementProps are the props for the [`dfn`](https://developer.mozilla.org/docs/Web/HTML/Element/dfn) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/dfn>
+ */
+export type DfnElementProps = GlobalAttributes;
+
+/**
  * dfn renders the [`dfn`](https://developer.mozilla.org/docs/Web/HTML/Element/dfn) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/dfn>
  */
-export function dfn(props?: GlobalAttributes, ...children: string[]): string {
+export function dfn(props?: DfnElementProps, ...children: string[]): string {
   return renderElement("dfn", props as AnyProps, false, children);
 }

--- a/dfn.ts
+++ b/dfn.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * DfnElementProps are the props for the [`dfn`](https://developer.mozilla.org/docs/Web/HTML/Element/dfn) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/dfn>
  */
-export type DfnElementProps = GlobalAttributes;
+export interface DfnElementProps extends GlobalAttributes {
+}
 
 /**
  * dfn renders the [`dfn`](https://developer.mozilla.org/docs/Web/HTML/Element/dfn) element.

--- a/dialog.ts
+++ b/dialog.ts
@@ -2,10 +2,11 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * DialogProps are the props for the [`dialog`](https://developer.mozilla.org/docs/Web/HTML/Element/dialog) element.
+ * DialogElementProps are the props for the [`dialog`](https://developer.mozilla.org/docs/Web/HTML/Element/dialog) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/dialog>
  */
-export interface DialogProps extends GlobalAttributes {
+export interface DialogElementProps extends GlobalAttributes {
+  /** `open` is an attribute of the [`dialog`](https://developer.mozilla.org/docs/Web/HTML/Element/dialog) element. */
   open?: string | undefined;
 }
 
@@ -13,6 +14,9 @@ export interface DialogProps extends GlobalAttributes {
  * dialog renders the [`dialog`](https://developer.mozilla.org/docs/Web/HTML/Element/dialog) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/dialog>
  */
-export function dialog(props?: DialogProps, ...children: string[]): string {
+export function dialog(
+  props?: DialogElementProps,
+  ...children: string[]
+): string {
   return renderElement("dialog", props as AnyProps, false, children);
 }

--- a/dir.ts
+++ b/dir.ts
@@ -2,12 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * DirProps are the props for the [`dir`](https://developer.mozilla.org/docs/Web/HTML/Element/dir) element.
+ * DirElementProps are the props for the [`dir`](https://developer.mozilla.org/docs/Web/HTML/Element/dir) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/dir>
  * @deprecated
  */
-export interface DirProps extends GlobalAttributes {
-  /** @deprecated */
+export interface DirElementProps extends GlobalAttributes {
+  /**
+   * `compact` is an attribute of the [`dir`](https://developer.mozilla.org/docs/Web/HTML/Element/dir) element.
+   * @deprecated
+   */
   compact?: string | undefined;
 }
 
@@ -16,6 +19,6 @@ export interface DirProps extends GlobalAttributes {
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/dir>
  * @deprecated
  */
-export function dir(props?: DirProps, ...children: string[]): string {
+export function dir(props?: DirElementProps, ...children: string[]): string {
   return renderElement("dir", props as AnyProps, false, children);
 }

--- a/div.ts
+++ b/div.ts
@@ -2,11 +2,14 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * DivProps are the props for the [`div`](https://developer.mozilla.org/docs/Web/HTML/Element/div) element.
+ * DivElementProps are the props for the [`div`](https://developer.mozilla.org/docs/Web/HTML/Element/div) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/div>
  */
-export interface DivProps extends GlobalAttributes {
-  /** @deprecated */
+export interface DivElementProps extends GlobalAttributes {
+  /**
+   * `align` is an attribute of the [`div`](https://developer.mozilla.org/docs/Web/HTML/Element/div) element.
+   * @deprecated
+   */
   align?: string | undefined;
 }
 
@@ -14,6 +17,6 @@ export interface DivProps extends GlobalAttributes {
  * div renders the [`div`](https://developer.mozilla.org/docs/Web/HTML/Element/div) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/div>
  */
-export function div(props?: DivProps, ...children: string[]): string {
+export function div(props?: DivElementProps, ...children: string[]): string {
   return renderElement("div", props as AnyProps, false, children);
 }

--- a/dl.ts
+++ b/dl.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * DlElementProps are the props for the [`dl`](https://developer.mozilla.org/docs/Web/HTML/Element/dl) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/dl>
  */
-export type DlElementProps = GlobalAttributes;
+export interface DlElementProps extends GlobalAttributes {
+}
 
 /**
  * dl renders the [`dl`](https://developer.mozilla.org/docs/Web/HTML/Element/dl) element.

--- a/dl.ts
+++ b/dl.ts
@@ -2,9 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * DlElementProps are the props for the [`dl`](https://developer.mozilla.org/docs/Web/HTML/Element/dl) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/dl>
+ */
+export type DlElementProps = GlobalAttributes;
+
+/**
  * dl renders the [`dl`](https://developer.mozilla.org/docs/Web/HTML/Element/dl) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/dl>
  */
-export function dl(props?: GlobalAttributes, ...children: string[]): string {
+export function dl(props?: DlElementProps, ...children: string[]): string {
   return renderElement("dl", props as AnyProps, false, children);
 }

--- a/dt.ts
+++ b/dt.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * DtElementProps are the props for the [`dt`](https://developer.mozilla.org/docs/Web/HTML/Element/dt) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/dt>
  */
-export type DtElementProps = GlobalAttributes;
+export interface DtElementProps extends GlobalAttributes {
+}
 
 /**
  * dt renders the [`dt`](https://developer.mozilla.org/docs/Web/HTML/Element/dt) element.

--- a/dt.ts
+++ b/dt.ts
@@ -2,9 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * DtElementProps are the props for the [`dt`](https://developer.mozilla.org/docs/Web/HTML/Element/dt) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/dt>
+ */
+export type DtElementProps = GlobalAttributes;
+
+/**
  * dt renders the [`dt`](https://developer.mozilla.org/docs/Web/HTML/Element/dt) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/dt>
  */
-export function dt(props?: GlobalAttributes, ...children: string[]): string {
+export function dt(props?: DtElementProps, ...children: string[]): string {
   return renderElement("dt", props as AnyProps, false, children);
 }

--- a/em.ts
+++ b/em.ts
@@ -2,9 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * EmElementProps are the props for the [`em`](https://developer.mozilla.org/docs/Web/HTML/Element/em) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/em>
+ */
+export type EmElementProps = GlobalAttributes;
+
+/**
  * em renders the [`em`](https://developer.mozilla.org/docs/Web/HTML/Element/em) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/em>
  */
-export function em(props?: GlobalAttributes, ...children: string[]): string {
+export function em(props?: EmElementProps, ...children: string[]): string {
   return renderElement("em", props as AnyProps, false, children);
 }

--- a/em.ts
+++ b/em.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * EmElementProps are the props for the [`em`](https://developer.mozilla.org/docs/Web/HTML/Element/em) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/em>
  */
-export type EmElementProps = GlobalAttributes;
+export interface EmElementProps extends GlobalAttributes {
+}
 
 /**
  * em renders the [`em`](https://developer.mozilla.org/docs/Web/HTML/Element/em) element.

--- a/embed.ts
+++ b/embed.ts
@@ -2,17 +2,27 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * EmbedProps are the props for the [`embed`](https://developer.mozilla.org/docs/Web/HTML/Element/embed) element.
+ * EmbedElementProps are the props for the [`embed`](https://developer.mozilla.org/docs/Web/HTML/Element/embed) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/embed>
  */
-export interface EmbedProps extends GlobalAttributes {
-  /** @deprecated */
+export interface EmbedElementProps extends GlobalAttributes {
+  /**
+   * `align` is an attribute of the [`embed`](https://developer.mozilla.org/docs/Web/HTML/Element/embed) element.
+   * @deprecated
+   */
   align?: string | undefined;
+  /** `height` is an attribute of the [`embed`](https://developer.mozilla.org/docs/Web/HTML/Element/embed) element. */
   height?: string | undefined;
-  /** @deprecated */
+  /**
+   * `name` is an attribute of the [`embed`](https://developer.mozilla.org/docs/Web/HTML/Element/embed) element.
+   * @deprecated
+   */
   name?: string | undefined;
+  /** `src` is an attribute of the [`embed`](https://developer.mozilla.org/docs/Web/HTML/Element/embed) element. */
   src?: string | undefined;
+  /** `type` is an attribute of the [`embed`](https://developer.mozilla.org/docs/Web/HTML/Element/embed) element. */
   type?: string | undefined;
+  /** `width` is an attribute of the [`embed`](https://developer.mozilla.org/docs/Web/HTML/Element/embed) element. */
   width?: string | undefined;
 }
 
@@ -20,6 +30,6 @@ export interface EmbedProps extends GlobalAttributes {
  * embed renders the [`embed`](https://developer.mozilla.org/docs/Web/HTML/Element/embed) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/embed>
  */
-export function embed(props?: EmbedProps): string {
+export function embed(props?: EmbedElementProps): string {
   return renderElement("embed", props as AnyProps, true);
 }

--- a/fencedframe.ts
+++ b/fencedframe.ts
@@ -6,7 +6,8 @@ import { renderElement } from "./lib/mod.ts";
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/fencedframe>
  * @experimental
  */
-export type FencedframeElementProps = GlobalAttributes;
+export interface FencedframeElementProps extends GlobalAttributes {
+}
 
 /**
  * fencedframe renders the [`fencedframe`](https://developer.mozilla.org/docs/Web/HTML/Element/fencedframe) element.

--- a/fencedframe.ts
+++ b/fencedframe.ts
@@ -2,12 +2,19 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * FencedframeElementProps are the props for the [`fencedframe`](https://developer.mozilla.org/docs/Web/HTML/Element/fencedframe) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/fencedframe>
+ * @experimental
+ */
+export type FencedframeElementProps = GlobalAttributes;
+
+/**
  * fencedframe renders the [`fencedframe`](https://developer.mozilla.org/docs/Web/HTML/Element/fencedframe) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/fencedframe>
  * @experimental
  */
 export function fencedframe(
-  props?: GlobalAttributes,
+  props?: FencedframeElementProps,
   ...children: string[]
 ): string {
   return renderElement("fencedframe", props as AnyProps, false, children);

--- a/fieldset.ts
+++ b/fieldset.ts
@@ -2,12 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * FieldsetProps are the props for the [`fieldset`](https://developer.mozilla.org/docs/Web/HTML/Element/fieldset) element.
+ * FieldsetElementProps are the props for the [`fieldset`](https://developer.mozilla.org/docs/Web/HTML/Element/fieldset) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/fieldset>
  */
-export interface FieldsetProps extends GlobalAttributes {
+export interface FieldsetElementProps extends GlobalAttributes {
+  /** `disabled` is an attribute of the [`fieldset`](https://developer.mozilla.org/docs/Web/HTML/Element/fieldset) element. */
   disabled?: string | undefined;
+  /** `form` is an attribute of the [`fieldset`](https://developer.mozilla.org/docs/Web/HTML/Element/fieldset) element. */
   form?: string | undefined;
+  /** `name` is an attribute of the [`fieldset`](https://developer.mozilla.org/docs/Web/HTML/Element/fieldset) element. */
   name?: string | undefined;
 }
 
@@ -15,6 +18,9 @@ export interface FieldsetProps extends GlobalAttributes {
  * fieldset renders the [`fieldset`](https://developer.mozilla.org/docs/Web/HTML/Element/fieldset) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/fieldset>
  */
-export function fieldset(props?: FieldsetProps, ...children: string[]): string {
+export function fieldset(
+  props?: FieldsetElementProps,
+  ...children: string[]
+): string {
   return renderElement("fieldset", props as AnyProps, false, children);
 }

--- a/figcaption.ts
+++ b/figcaption.ts
@@ -2,11 +2,17 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * FigcaptionElementProps are the props for the [`figcaption`](https://developer.mozilla.org/docs/Web/HTML/Element/figcaption) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/figcaption>
+ */
+export type FigcaptionElementProps = GlobalAttributes;
+
+/**
  * figcaption renders the [`figcaption`](https://developer.mozilla.org/docs/Web/HTML/Element/figcaption) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/figcaption>
  */
 export function figcaption(
-  props?: GlobalAttributes,
+  props?: FigcaptionElementProps,
   ...children: string[]
 ): string {
   return renderElement("figcaption", props as AnyProps, false, children);

--- a/figcaption.ts
+++ b/figcaption.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * FigcaptionElementProps are the props for the [`figcaption`](https://developer.mozilla.org/docs/Web/HTML/Element/figcaption) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/figcaption>
  */
-export type FigcaptionElementProps = GlobalAttributes;
+export interface FigcaptionElementProps extends GlobalAttributes {
+}
 
 /**
  * figcaption renders the [`figcaption`](https://developer.mozilla.org/docs/Web/HTML/Element/figcaption) element.

--- a/figure.ts
+++ b/figure.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * FigureElementProps are the props for the [`figure`](https://developer.mozilla.org/docs/Web/HTML/Element/figure) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/figure>
  */
-export type FigureElementProps = GlobalAttributes;
+export interface FigureElementProps extends GlobalAttributes {
+}
 
 /**
  * figure renders the [`figure`](https://developer.mozilla.org/docs/Web/HTML/Element/figure) element.

--- a/figure.ts
+++ b/figure.ts
@@ -2,11 +2,17 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * FigureElementProps are the props for the [`figure`](https://developer.mozilla.org/docs/Web/HTML/Element/figure) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/figure>
+ */
+export type FigureElementProps = GlobalAttributes;
+
+/**
  * figure renders the [`figure`](https://developer.mozilla.org/docs/Web/HTML/Element/figure) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/figure>
  */
 export function figure(
-  props?: GlobalAttributes,
+  props?: FigureElementProps,
   ...children: string[]
 ): string {
   return renderElement("figure", props as AnyProps, false, children);

--- a/font.ts
+++ b/font.ts
@@ -2,16 +2,25 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * FontProps are the props for the [`font`](https://developer.mozilla.org/docs/Web/HTML/Element/font) element.
+ * FontElementProps are the props for the [`font`](https://developer.mozilla.org/docs/Web/HTML/Element/font) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/font>
  * @deprecated
  */
-export interface FontProps extends GlobalAttributes {
-  /** @deprecated */
+export interface FontElementProps extends GlobalAttributes {
+  /**
+   * `color` is an attribute of the [`font`](https://developer.mozilla.org/docs/Web/HTML/Element/font) element.
+   * @deprecated
+   */
   color?: string | undefined;
-  /** @deprecated */
+  /**
+   * `face` is an attribute of the [`font`](https://developer.mozilla.org/docs/Web/HTML/Element/font) element.
+   * @deprecated
+   */
   face?: string | undefined;
-  /** @deprecated */
+  /**
+   * `size` is an attribute of the [`font`](https://developer.mozilla.org/docs/Web/HTML/Element/font) element.
+   * @deprecated
+   */
   size?: string | undefined;
 }
 
@@ -20,6 +29,6 @@ export interface FontProps extends GlobalAttributes {
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/font>
  * @deprecated
  */
-export function font(props?: FontProps, ...children: string[]): string {
+export function font(props?: FontElementProps, ...children: string[]): string {
   return renderElement("font", props as AnyProps, false, children);
 }

--- a/footer.ts
+++ b/footer.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * FooterElementProps are the props for the [`footer`](https://developer.mozilla.org/docs/Web/HTML/Element/footer) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/footer>
  */
-export type FooterElementProps = GlobalAttributes;
+export interface FooterElementProps extends GlobalAttributes {
+}
 
 /**
  * footer renders the [`footer`](https://developer.mozilla.org/docs/Web/HTML/Element/footer) element.

--- a/footer.ts
+++ b/footer.ts
@@ -2,11 +2,17 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * FooterElementProps are the props for the [`footer`](https://developer.mozilla.org/docs/Web/HTML/Element/footer) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/footer>
+ */
+export type FooterElementProps = GlobalAttributes;
+
+/**
  * footer renders the [`footer`](https://developer.mozilla.org/docs/Web/HTML/Element/footer) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/footer>
  */
 export function footer(
-  props?: GlobalAttributes,
+  props?: FooterElementProps,
   ...children: string[]
 ): string {
   return renderElement("footer", props as AnyProps, false, children);

--- a/form.ts
+++ b/form.ts
@@ -2,18 +2,27 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * FormProps are the props for the [`form`](https://developer.mozilla.org/docs/Web/HTML/Element/form) element.
+ * FormElementProps are the props for the [`form`](https://developer.mozilla.org/docs/Web/HTML/Element/form) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/form>
  */
-export interface FormProps extends GlobalAttributes {
+export interface FormElementProps extends GlobalAttributes {
+  /** `accept-charset` is an attribute of the [`form`](https://developer.mozilla.org/docs/Web/HTML/Element/form) element. */
   "accept-charset"?: string | undefined;
+  /** `action` is an attribute of the [`form`](https://developer.mozilla.org/docs/Web/HTML/Element/form) element. */
   action?: string | undefined;
+  /** `autocomplete` is an attribute of the [`form`](https://developer.mozilla.org/docs/Web/HTML/Element/form) element. */
   autocomplete?: string | undefined;
+  /** `enctype` is an attribute of the [`form`](https://developer.mozilla.org/docs/Web/HTML/Element/form) element. */
   enctype?: string | undefined;
+  /** `method` is an attribute of the [`form`](https://developer.mozilla.org/docs/Web/HTML/Element/form) element. */
   method?: string | undefined;
+  /** `name` is an attribute of the [`form`](https://developer.mozilla.org/docs/Web/HTML/Element/form) element. */
   name?: string | undefined;
+  /** `novalidate` is an attribute of the [`form`](https://developer.mozilla.org/docs/Web/HTML/Element/form) element. */
   novalidate?: string | undefined;
+  /** `rel` is an attribute of the [`form`](https://developer.mozilla.org/docs/Web/HTML/Element/form) element. */
   rel?: string | undefined;
+  /** `target` is an attribute of the [`form`](https://developer.mozilla.org/docs/Web/HTML/Element/form) element. */
   target?: string | undefined;
 }
 
@@ -21,6 +30,6 @@ export interface FormProps extends GlobalAttributes {
  * form renders the [`form`](https://developer.mozilla.org/docs/Web/HTML/Element/form) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/form>
  */
-export function form(props?: FormProps, ...children: string[]): string {
+export function form(props?: FormElementProps, ...children: string[]): string {
   return renderElement("form", props as AnyProps, false, children);
 }

--- a/frame.ts
+++ b/frame.ts
@@ -2,24 +2,45 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * FrameProps are the props for the [`frame`](https://developer.mozilla.org/docs/Web/HTML/Element/frame) element.
+ * FrameElementProps are the props for the [`frame`](https://developer.mozilla.org/docs/Web/HTML/Element/frame) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/frame>
  * @deprecated
  */
-export interface FrameProps extends GlobalAttributes {
-  /** @deprecated */
+export interface FrameElementProps extends GlobalAttributes {
+  /**
+   * `frameborder` is an attribute of the [`frame`](https://developer.mozilla.org/docs/Web/HTML/Element/frame) element.
+   * @deprecated
+   */
   frameborder?: string | undefined;
-  /** @deprecated */
+  /**
+   * `marginheight` is an attribute of the [`frame`](https://developer.mozilla.org/docs/Web/HTML/Element/frame) element.
+   * @deprecated
+   */
   marginheight?: string | undefined;
-  /** @deprecated */
+  /**
+   * `marginwidth` is an attribute of the [`frame`](https://developer.mozilla.org/docs/Web/HTML/Element/frame) element.
+   * @deprecated
+   */
   marginwidth?: string | undefined;
-  /** @deprecated */
+  /**
+   * `name` is an attribute of the [`frame`](https://developer.mozilla.org/docs/Web/HTML/Element/frame) element.
+   * @deprecated
+   */
   name?: string | undefined;
-  /** @deprecated */
+  /**
+   * `noresize` is an attribute of the [`frame`](https://developer.mozilla.org/docs/Web/HTML/Element/frame) element.
+   * @deprecated
+   */
   noresize?: string | undefined;
-  /** @deprecated */
+  /**
+   * `scrolling` is an attribute of the [`frame`](https://developer.mozilla.org/docs/Web/HTML/Element/frame) element.
+   * @deprecated
+   */
   scrolling?: string | undefined;
-  /** @deprecated */
+  /**
+   * `src` is an attribute of the [`frame`](https://developer.mozilla.org/docs/Web/HTML/Element/frame) element.
+   * @deprecated
+   */
   src?: string | undefined;
 }
 
@@ -28,6 +49,9 @@ export interface FrameProps extends GlobalAttributes {
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/frame>
  * @deprecated
  */
-export function frame(props?: FrameProps, ...children: string[]): string {
+export function frame(
+  props?: FrameElementProps,
+  ...children: string[]
+): string {
   return renderElement("frame", props as AnyProps, false, children);
 }

--- a/frameset.ts
+++ b/frameset.ts
@@ -2,14 +2,20 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * FramesetProps are the props for the [`frameset`](https://developer.mozilla.org/docs/Web/HTML/Element/frameset) element.
+ * FramesetElementProps are the props for the [`frameset`](https://developer.mozilla.org/docs/Web/HTML/Element/frameset) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/frameset>
  * @deprecated
  */
-export interface FramesetProps extends GlobalAttributes {
-  /** @deprecated */
+export interface FramesetElementProps extends GlobalAttributes {
+  /**
+   * `cols` is an attribute of the [`frameset`](https://developer.mozilla.org/docs/Web/HTML/Element/frameset) element.
+   * @deprecated
+   */
   cols?: string | undefined;
-  /** @deprecated */
+  /**
+   * `rows` is an attribute of the [`frameset`](https://developer.mozilla.org/docs/Web/HTML/Element/frameset) element.
+   * @deprecated
+   */
   rows?: string | undefined;
 }
 
@@ -18,6 +24,9 @@ export interface FramesetProps extends GlobalAttributes {
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/frameset>
  * @deprecated
  */
-export function frameset(props?: FramesetProps, ...children: string[]): string {
+export function frameset(
+  props?: FramesetElementProps,
+  ...children: string[]
+): string {
   return renderElement("frameset", props as AnyProps, false, children);
 }

--- a/h1.ts
+++ b/h1.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * H1ElementProps are the props for the [`h1`](https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements>
  */
-export type H1ElementProps = GlobalAttributes;
+export interface H1ElementProps extends GlobalAttributes {
+}
 
 /**
  * h1 renders the [`h1`](https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements) element.

--- a/h1.ts
+++ b/h1.ts
@@ -2,9 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * H1ElementProps are the props for the [`h1`](https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements>
+ */
+export type H1ElementProps = GlobalAttributes;
+
+/**
  * h1 renders the [`h1`](https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements>
  */
-export function h1(props?: GlobalAttributes, ...children: string[]): string {
+export function h1(props?: H1ElementProps, ...children: string[]): string {
   return renderElement("h1", props as AnyProps, false, children);
 }

--- a/h2.ts
+++ b/h2.ts
@@ -2,9 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * H2ElementProps are the props for the [`h2`](https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements>
+ */
+export type H2ElementProps = GlobalAttributes;
+
+/**
  * h2 renders the [`h2`](https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements>
  */
-export function h2(props?: GlobalAttributes, ...children: string[]): string {
+export function h2(props?: H2ElementProps, ...children: string[]): string {
   return renderElement("h2", props as AnyProps, false, children);
 }

--- a/h2.ts
+++ b/h2.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * H2ElementProps are the props for the [`h2`](https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements>
  */
-export type H2ElementProps = GlobalAttributes;
+export interface H2ElementProps extends GlobalAttributes {
+}
 
 /**
  * h2 renders the [`h2`](https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements) element.

--- a/h3.ts
+++ b/h3.ts
@@ -2,9 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * H3ElementProps are the props for the [`h3`](https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements>
+ */
+export type H3ElementProps = GlobalAttributes;
+
+/**
  * h3 renders the [`h3`](https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements>
  */
-export function h3(props?: GlobalAttributes, ...children: string[]): string {
+export function h3(props?: H3ElementProps, ...children: string[]): string {
   return renderElement("h3", props as AnyProps, false, children);
 }

--- a/h3.ts
+++ b/h3.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * H3ElementProps are the props for the [`h3`](https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements>
  */
-export type H3ElementProps = GlobalAttributes;
+export interface H3ElementProps extends GlobalAttributes {
+}
 
 /**
  * h3 renders the [`h3`](https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements) element.

--- a/h4.ts
+++ b/h4.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * H4ElementProps are the props for the [`h4`](https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements>
  */
-export type H4ElementProps = GlobalAttributes;
+export interface H4ElementProps extends GlobalAttributes {
+}
 
 /**
  * h4 renders the [`h4`](https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements) element.

--- a/h4.ts
+++ b/h4.ts
@@ -2,9 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * H4ElementProps are the props for the [`h4`](https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements>
+ */
+export type H4ElementProps = GlobalAttributes;
+
+/**
  * h4 renders the [`h4`](https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements>
  */
-export function h4(props?: GlobalAttributes, ...children: string[]): string {
+export function h4(props?: H4ElementProps, ...children: string[]): string {
   return renderElement("h4", props as AnyProps, false, children);
 }

--- a/h5.ts
+++ b/h5.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * H5ElementProps are the props for the [`h5`](https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements>
  */
-export type H5ElementProps = GlobalAttributes;
+export interface H5ElementProps extends GlobalAttributes {
+}
 
 /**
  * h5 renders the [`h5`](https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements) element.

--- a/h5.ts
+++ b/h5.ts
@@ -2,9 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * H5ElementProps are the props for the [`h5`](https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements>
+ */
+export type H5ElementProps = GlobalAttributes;
+
+/**
  * h5 renders the [`h5`](https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements>
  */
-export function h5(props?: GlobalAttributes, ...children: string[]): string {
+export function h5(props?: H5ElementProps, ...children: string[]): string {
   return renderElement("h5", props as AnyProps, false, children);
 }

--- a/h6.ts
+++ b/h6.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * H6ElementProps are the props for the [`h6`](https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements>
  */
-export type H6ElementProps = GlobalAttributes;
+export interface H6ElementProps extends GlobalAttributes {
+}
 
 /**
  * h6 renders the [`h6`](https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements) element.

--- a/h6.ts
+++ b/h6.ts
@@ -2,9 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * H6ElementProps are the props for the [`h6`](https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements>
+ */
+export type H6ElementProps = GlobalAttributes;
+
+/**
  * h6 renders the [`h6`](https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/Heading_Elements>
  */
-export function h6(props?: GlobalAttributes, ...children: string[]): string {
+export function h6(props?: H6ElementProps, ...children: string[]): string {
   return renderElement("h6", props as AnyProps, false, children);
 }

--- a/head.ts
+++ b/head.ts
@@ -2,11 +2,14 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * HeadProps are the props for the [`head`](https://developer.mozilla.org/docs/Web/HTML/Element/head) element.
+ * HeadElementProps are the props for the [`head`](https://developer.mozilla.org/docs/Web/HTML/Element/head) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/head>
  */
-export interface HeadProps extends GlobalAttributes {
-  /** @deprecated */
+export interface HeadElementProps extends GlobalAttributes {
+  /**
+   * `profile` is an attribute of the [`head`](https://developer.mozilla.org/docs/Web/HTML/Element/head) element.
+   * @deprecated
+   */
   profile?: string | undefined;
 }
 
@@ -14,6 +17,6 @@ export interface HeadProps extends GlobalAttributes {
  * head renders the [`head`](https://developer.mozilla.org/docs/Web/HTML/Element/head) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/head>
  */
-export function head(props?: HeadProps, ...children: string[]): string {
+export function head(props?: HeadElementProps, ...children: string[]): string {
   return renderElement("head", props as AnyProps, false, children);
 }

--- a/header.ts
+++ b/header.ts
@@ -2,11 +2,17 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * HeaderElementProps are the props for the [`header`](https://developer.mozilla.org/docs/Web/HTML/Element/header) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/header>
+ */
+export type HeaderElementProps = GlobalAttributes;
+
+/**
  * header renders the [`header`](https://developer.mozilla.org/docs/Web/HTML/Element/header) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/header>
  */
 export function header(
-  props?: GlobalAttributes,
+  props?: HeaderElementProps,
   ...children: string[]
 ): string {
   return renderElement("header", props as AnyProps, false, children);

--- a/header.ts
+++ b/header.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * HeaderElementProps are the props for the [`header`](https://developer.mozilla.org/docs/Web/HTML/Element/header) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/header>
  */
-export type HeaderElementProps = GlobalAttributes;
+export interface HeaderElementProps extends GlobalAttributes {
+}
 
 /**
  * header renders the [`header`](https://developer.mozilla.org/docs/Web/HTML/Element/header) element.

--- a/hgroup.ts
+++ b/hgroup.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * HgroupElementProps are the props for the [`hgroup`](https://developer.mozilla.org/docs/Web/HTML/Element/hgroup) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/hgroup>
  */
-export type HgroupElementProps = GlobalAttributes;
+export interface HgroupElementProps extends GlobalAttributes {
+}
 
 /**
  * hgroup renders the [`hgroup`](https://developer.mozilla.org/docs/Web/HTML/Element/hgroup) element.

--- a/hgroup.ts
+++ b/hgroup.ts
@@ -2,11 +2,17 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * HgroupElementProps are the props for the [`hgroup`](https://developer.mozilla.org/docs/Web/HTML/Element/hgroup) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/hgroup>
+ */
+export type HgroupElementProps = GlobalAttributes;
+
+/**
  * hgroup renders the [`hgroup`](https://developer.mozilla.org/docs/Web/HTML/Element/hgroup) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/hgroup>
  */
 export function hgroup(
-  props?: GlobalAttributes,
+  props?: HgroupElementProps,
   ...children: string[]
 ): string {
   return renderElement("hgroup", props as AnyProps, false, children);

--- a/hr.ts
+++ b/hr.ts
@@ -2,19 +2,34 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * HrProps are the props for the [`hr`](https://developer.mozilla.org/docs/Web/HTML/Element/hr) element.
+ * HrElementProps are the props for the [`hr`](https://developer.mozilla.org/docs/Web/HTML/Element/hr) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/hr>
  */
-export interface HrProps extends GlobalAttributes {
-  /** @deprecated */
+export interface HrElementProps extends GlobalAttributes {
+  /**
+   * `align` is an attribute of the [`hr`](https://developer.mozilla.org/docs/Web/HTML/Element/hr) element.
+   * @deprecated
+   */
   align?: string | undefined;
-  /** @deprecated */
+  /**
+   * `color` is an attribute of the [`hr`](https://developer.mozilla.org/docs/Web/HTML/Element/hr) element.
+   * @deprecated
+   */
   color?: string | undefined;
-  /** @deprecated */
+  /**
+   * `noshade` is an attribute of the [`hr`](https://developer.mozilla.org/docs/Web/HTML/Element/hr) element.
+   * @deprecated
+   */
   noshade?: string | undefined;
-  /** @deprecated */
+  /**
+   * `size` is an attribute of the [`hr`](https://developer.mozilla.org/docs/Web/HTML/Element/hr) element.
+   * @deprecated
+   */
   size?: string | undefined;
-  /** @deprecated */
+  /**
+   * `width` is an attribute of the [`hr`](https://developer.mozilla.org/docs/Web/HTML/Element/hr) element.
+   * @deprecated
+   */
   width?: string | undefined;
 }
 
@@ -22,6 +37,6 @@ export interface HrProps extends GlobalAttributes {
  * hr renders the [`hr`](https://developer.mozilla.org/docs/Web/HTML/Element/hr) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/hr>
  */
-export function hr(props?: HrProps): string {
+export function hr(props?: HrElementProps): string {
   return renderElement("hr", props as AnyProps, true);
 }

--- a/html.ts
+++ b/html.ts
@@ -2,14 +2,21 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * HtmlProps are the props for the [`html`](https://developer.mozilla.org/docs/Web/HTML/Element/html) element.
+ * HtmlElementProps are the props for the [`html`](https://developer.mozilla.org/docs/Web/HTML/Element/html) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/html>
  */
-export interface HtmlProps extends GlobalAttributes {
-  /** @deprecated */
+export interface HtmlElementProps extends GlobalAttributes {
+  /**
+   * `manifest` is an attribute of the [`html`](https://developer.mozilla.org/docs/Web/HTML/Element/html) element.
+   * @deprecated
+   */
   manifest?: string | undefined;
-  /** @deprecated */
+  /**
+   * `version` is an attribute of the [`html`](https://developer.mozilla.org/docs/Web/HTML/Element/html) element.
+   * @deprecated
+   */
   version?: string | undefined;
+  /** `xmlns` is an attribute of the [`html`](https://developer.mozilla.org/docs/Web/HTML/Element/html) element. */
   xmlns?: string | undefined;
 }
 
@@ -17,6 +24,6 @@ export interface HtmlProps extends GlobalAttributes {
  * html renders the [`html`](https://developer.mozilla.org/docs/Web/HTML/Element/html) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/html>
  */
-export function html(props?: HtmlProps, ...children: string[]): string {
+export function html(props?: HtmlElementProps, ...children: string[]): string {
   return renderElement("html", props as AnyProps, false, children);
 }

--- a/i.ts
+++ b/i.ts
@@ -2,9 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * IElementProps are the props for the [`i`](https://developer.mozilla.org/docs/Web/HTML/Element/i) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/i>
+ */
+export type IElementProps = GlobalAttributes;
+
+/**
  * i renders the [`i`](https://developer.mozilla.org/docs/Web/HTML/Element/i) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/i>
  */
-export function i(props?: GlobalAttributes, ...children: string[]): string {
+export function i(props?: IElementProps, ...children: string[]): string {
   return renderElement("i", props as AnyProps, false, children);
 }

--- a/i.ts
+++ b/i.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * IElementProps are the props for the [`i`](https://developer.mozilla.org/docs/Web/HTML/Element/i) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/i>
  */
-export type IElementProps = GlobalAttributes;
+export interface IElementProps extends GlobalAttributes {
+}
 
 /**
  * i renders the [`i`](https://developer.mozilla.org/docs/Web/HTML/Element/i) element.

--- a/iframe.ts
+++ b/iframe.ts
@@ -2,39 +2,79 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * IframeProps are the props for the [`iframe`](https://developer.mozilla.org/docs/Web/HTML/Element/iframe) element.
+ * IframeElementProps are the props for the [`iframe`](https://developer.mozilla.org/docs/Web/HTML/Element/iframe) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/iframe>
  */
-export interface IframeProps extends GlobalAttributes {
-  /** @deprecated */
+export interface IframeElementProps extends GlobalAttributes {
+  /**
+   * `align` is an attribute of the [`iframe`](https://developer.mozilla.org/docs/Web/HTML/Element/iframe) element.
+   * @deprecated
+   */
   align?: string | undefined;
+  /** `allow` is an attribute of the [`iframe`](https://developer.mozilla.org/docs/Web/HTML/Element/iframe) element. */
   allow?: string | undefined;
+  /** `allowfullscreen` is an attribute of the [`iframe`](https://developer.mozilla.org/docs/Web/HTML/Element/iframe) element. */
   allowfullscreen?: string | undefined;
-  /** @deprecated */
+  /**
+   * `allowpaymentrequest` is an attribute of the [`iframe`](https://developer.mozilla.org/docs/Web/HTML/Element/iframe) element.
+   * @deprecated
+   */
   allowpaymentrequest?: string | undefined;
-  /** @experimental */
+  /**
+   * `browsingtopics` is an attribute of the [`iframe`](https://developer.mozilla.org/docs/Web/HTML/Element/iframe) element.
+   * @experimental
+   */
   browsingtopics?: string | undefined;
-  /** @experimental */
+  /**
+   * `credentialless` is an attribute of the [`iframe`](https://developer.mozilla.org/docs/Web/HTML/Element/iframe) element.
+   * @experimental
+   */
   credentialless?: string | undefined;
-  /** @experimental */
+  /**
+   * `csp` is an attribute of the [`iframe`](https://developer.mozilla.org/docs/Web/HTML/Element/iframe) element.
+   * @experimental
+   */
   csp?: string | undefined;
-  /** @deprecated */
+  /**
+   * `frameborder` is an attribute of the [`iframe`](https://developer.mozilla.org/docs/Web/HTML/Element/iframe) element.
+   * @deprecated
+   */
   frameborder?: string | undefined;
+  /** `height` is an attribute of the [`iframe`](https://developer.mozilla.org/docs/Web/HTML/Element/iframe) element. */
   height?: string | undefined;
+  /** `loading` is an attribute of the [`iframe`](https://developer.mozilla.org/docs/Web/HTML/Element/iframe) element. */
   loading?: string | undefined;
-  /** @deprecated */
+  /**
+   * `longdesc` is an attribute of the [`iframe`](https://developer.mozilla.org/docs/Web/HTML/Element/iframe) element.
+   * @deprecated
+   */
   longdesc?: string | undefined;
-  /** @deprecated */
+  /**
+   * `marginheight` is an attribute of the [`iframe`](https://developer.mozilla.org/docs/Web/HTML/Element/iframe) element.
+   * @deprecated
+   */
   marginheight?: string | undefined;
-  /** @deprecated */
+  /**
+   * `marginwidth` is an attribute of the [`iframe`](https://developer.mozilla.org/docs/Web/HTML/Element/iframe) element.
+   * @deprecated
+   */
   marginwidth?: string | undefined;
+  /** `name` is an attribute of the [`iframe`](https://developer.mozilla.org/docs/Web/HTML/Element/iframe) element. */
   name?: string | undefined;
+  /** `referrerpolicy` is an attribute of the [`iframe`](https://developer.mozilla.org/docs/Web/HTML/Element/iframe) element. */
   referrerpolicy?: string | undefined;
+  /** `sandbox` is an attribute of the [`iframe`](https://developer.mozilla.org/docs/Web/HTML/Element/iframe) element. */
   sandbox?: string | undefined;
-  /** @deprecated */
+  /**
+   * `scrolling` is an attribute of the [`iframe`](https://developer.mozilla.org/docs/Web/HTML/Element/iframe) element.
+   * @deprecated
+   */
   scrolling?: string | undefined;
+  /** `src` is an attribute of the [`iframe`](https://developer.mozilla.org/docs/Web/HTML/Element/iframe) element. */
   src?: string | undefined;
+  /** `srcdoc` is an attribute of the [`iframe`](https://developer.mozilla.org/docs/Web/HTML/Element/iframe) element. */
   srcdoc?: string | undefined;
+  /** `width` is an attribute of the [`iframe`](https://developer.mozilla.org/docs/Web/HTML/Element/iframe) element. */
   width?: string | undefined;
 }
 
@@ -42,6 +82,9 @@ export interface IframeProps extends GlobalAttributes {
  * iframe renders the [`iframe`](https://developer.mozilla.org/docs/Web/HTML/Element/iframe) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/iframe>
  */
-export function iframe(props?: IframeProps, ...children: string[]): string {
+export function iframe(
+  props?: IframeElementProps,
+  ...children: string[]
+): string {
   return renderElement("iframe", props as AnyProps, false, children);
 }

--- a/img.ts
+++ b/img.ts
@@ -2,36 +2,70 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * ImgProps are the props for the [`img`](https://developer.mozilla.org/docs/Web/HTML/Element/img) element.
+ * ImgElementProps are the props for the [`img`](https://developer.mozilla.org/docs/Web/HTML/Element/img) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/img>
  */
-export interface ImgProps extends GlobalAttributes {
-  /** @deprecated */
+export interface ImgElementProps extends GlobalAttributes {
+  /**
+   * `align` is an attribute of the [`img`](https://developer.mozilla.org/docs/Web/HTML/Element/img) element.
+   * @deprecated
+   */
   align?: string | undefined;
+  /** `alt` is an attribute of the [`img`](https://developer.mozilla.org/docs/Web/HTML/Element/img) element. */
   alt?: string | undefined;
-  /** @experimental */
+  /**
+   * `attributionsrc` is an attribute of the [`img`](https://developer.mozilla.org/docs/Web/HTML/Element/img) element.
+   * @experimental
+   */
   attributionsrc?: string | undefined;
-  /** @deprecated */
+  /**
+   * `border` is an attribute of the [`img`](https://developer.mozilla.org/docs/Web/HTML/Element/img) element.
+   * @deprecated
+   */
   border?: string | undefined;
+  /** `crossorigin` is an attribute of the [`img`](https://developer.mozilla.org/docs/Web/HTML/Element/img) element. */
   crossorigin?: string | undefined;
+  /** `decoding` is an attribute of the [`img`](https://developer.mozilla.org/docs/Web/HTML/Element/img) element. */
   decoding?: string | undefined;
+  /** `fetchpriority` is an attribute of the [`img`](https://developer.mozilla.org/docs/Web/HTML/Element/img) element. */
   fetchpriority?: string | undefined;
+  /** `height` is an attribute of the [`img`](https://developer.mozilla.org/docs/Web/HTML/Element/img) element. */
   height?: string | undefined;
-  /** @deprecated */
+  /**
+   * `hspace` is an attribute of the [`img`](https://developer.mozilla.org/docs/Web/HTML/Element/img) element.
+   * @deprecated
+   */
   hspace?: string | undefined;
+  /** `ismap` is an attribute of the [`img`](https://developer.mozilla.org/docs/Web/HTML/Element/img) element. */
   ismap?: string | undefined;
+  /** `loading` is an attribute of the [`img`](https://developer.mozilla.org/docs/Web/HTML/Element/img) element. */
   loading?: string | undefined;
-  /** @deprecated */
+  /**
+   * `longdesc` is an attribute of the [`img`](https://developer.mozilla.org/docs/Web/HTML/Element/img) element.
+   * @deprecated
+   */
   longdesc?: string | undefined;
-  /** @deprecated */
+  /**
+   * `name` is an attribute of the [`img`](https://developer.mozilla.org/docs/Web/HTML/Element/img) element.
+   * @deprecated
+   */
   name?: string | undefined;
+  /** `referrerpolicy` is an attribute of the [`img`](https://developer.mozilla.org/docs/Web/HTML/Element/img) element. */
   referrerpolicy?: string | undefined;
+  /** `sizes` is an attribute of the [`img`](https://developer.mozilla.org/docs/Web/HTML/Element/img) element. */
   sizes?: string | undefined;
+  /** `src` is an attribute of the [`img`](https://developer.mozilla.org/docs/Web/HTML/Element/img) element. */
   src?: string | undefined;
+  /** `srcset` is an attribute of the [`img`](https://developer.mozilla.org/docs/Web/HTML/Element/img) element. */
   srcset?: string | undefined;
+  /** `usemap` is an attribute of the [`img`](https://developer.mozilla.org/docs/Web/HTML/Element/img) element. */
   usemap?: string | undefined;
-  /** @deprecated */
+  /**
+   * `vspace` is an attribute of the [`img`](https://developer.mozilla.org/docs/Web/HTML/Element/img) element.
+   * @deprecated
+   */
   vspace?: string | undefined;
+  /** `width` is an attribute of the [`img`](https://developer.mozilla.org/docs/Web/HTML/Element/img) element. */
   width?: string | undefined;
 }
 
@@ -39,6 +73,6 @@ export interface ImgProps extends GlobalAttributes {
  * img renders the [`img`](https://developer.mozilla.org/docs/Web/HTML/Element/img) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/img>
  */
-export function img(props?: ImgProps): string {
+export function img(props?: ImgElementProps): string {
   return renderElement("img", props as AnyProps, true);
 }

--- a/input.ts
+++ b/input.ts
@@ -2,43 +2,81 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * InputProps are the props for the [`input`](https://developer.mozilla.org/docs/Web/HTML/Element/input) element.
+ * InputElementProps are the props for the [`input`](https://developer.mozilla.org/docs/Web/HTML/Element/input) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/input>
  */
-export interface InputProps extends GlobalAttributes {
+export interface InputElementProps extends GlobalAttributes {
+  /** `accept` is an attribute of the [`input`](https://developer.mozilla.org/docs/Web/HTML/Element/input) element. */
   accept?: string | undefined;
-  /** @deprecated */
+  /**
+   * `align` is an attribute of the [`input`](https://developer.mozilla.org/docs/Web/HTML/Element/input) element.
+   * @deprecated
+   */
   align?: string | undefined;
+  /** `alt` is an attribute of the [`input`](https://developer.mozilla.org/docs/Web/HTML/Element/input) element. */
   alt?: string | undefined;
+  /** `capture` is an attribute of the [`input`](https://developer.mozilla.org/docs/Web/HTML/Element/input) element. */
   capture?: string | undefined;
+  /** `checked` is an attribute of the [`input`](https://developer.mozilla.org/docs/Web/HTML/Element/input) element. */
   checked?: string | undefined;
+  /** `dirname` is an attribute of the [`input`](https://developer.mozilla.org/docs/Web/HTML/Element/input) element. */
   dirname?: string | undefined;
+  /** `disabled` is an attribute of the [`input`](https://developer.mozilla.org/docs/Web/HTML/Element/input) element. */
   disabled?: string | undefined;
+  /** `form` is an attribute of the [`input`](https://developer.mozilla.org/docs/Web/HTML/Element/input) element. */
   form?: string | undefined;
+  /** `formaction` is an attribute of the [`input`](https://developer.mozilla.org/docs/Web/HTML/Element/input) element. */
   formaction?: string | undefined;
+  /** `formenctype` is an attribute of the [`input`](https://developer.mozilla.org/docs/Web/HTML/Element/input) element. */
   formenctype?: string | undefined;
+  /** `formmethod` is an attribute of the [`input`](https://developer.mozilla.org/docs/Web/HTML/Element/input) element. */
   formmethod?: string | undefined;
+  /** `formnovalidate` is an attribute of the [`input`](https://developer.mozilla.org/docs/Web/HTML/Element/input) element. */
   formnovalidate?: string | undefined;
+  /** `formtarget` is an attribute of the [`input`](https://developer.mozilla.org/docs/Web/HTML/Element/input) element. */
   formtarget?: string | undefined;
+  /** `list` is an attribute of the [`input`](https://developer.mozilla.org/docs/Web/HTML/Element/input) element. */
   list?: string | undefined;
+  /** `max` is an attribute of the [`input`](https://developer.mozilla.org/docs/Web/HTML/Element/input) element. */
   max?: string | undefined;
+  /** `maxlength` is an attribute of the [`input`](https://developer.mozilla.org/docs/Web/HTML/Element/input) element. */
   maxlength?: string | undefined;
+  /** `min` is an attribute of the [`input`](https://developer.mozilla.org/docs/Web/HTML/Element/input) element. */
   min?: string | undefined;
+  /** `minlength` is an attribute of the [`input`](https://developer.mozilla.org/docs/Web/HTML/Element/input) element. */
   minlength?: string | undefined;
-  /** @deprecated */
+  /**
+   * `mozactionhint` is an attribute of the [`input`](https://developer.mozilla.org/docs/Web/HTML/Element/input) element.
+   * @deprecated
+   */
   mozactionhint?: string | undefined;
+  /** `multiple` is an attribute of the [`input`](https://developer.mozilla.org/docs/Web/HTML/Element/input) element. */
   multiple?: string | undefined;
+  /** `name` is an attribute of the [`input`](https://developer.mozilla.org/docs/Web/HTML/Element/input) element. */
   name?: string | undefined;
+  /** `pattern` is an attribute of the [`input`](https://developer.mozilla.org/docs/Web/HTML/Element/input) element. */
   pattern?: string | undefined;
+  /** `placeholder` is an attribute of the [`input`](https://developer.mozilla.org/docs/Web/HTML/Element/input) element. */
   placeholder?: string | undefined;
+  /** `popovertarget` is an attribute of the [`input`](https://developer.mozilla.org/docs/Web/HTML/Element/input) element. */
   popovertarget?: string | undefined;
+  /** `popovertargetaction` is an attribute of the [`input`](https://developer.mozilla.org/docs/Web/HTML/Element/input) element. */
   popovertargetaction?: string | undefined;
+  /** `readonly` is an attribute of the [`input`](https://developer.mozilla.org/docs/Web/HTML/Element/input) element. */
   readonly?: string | undefined;
+  /** `src` is an attribute of the [`input`](https://developer.mozilla.org/docs/Web/HTML/Element/input) element. */
   src?: string | undefined;
+  /** `step` is an attribute of the [`input`](https://developer.mozilla.org/docs/Web/HTML/Element/input) element. */
   step?: string | undefined;
-  /** @deprecated */
+  /**
+   * `usemap` is an attribute of the [`input`](https://developer.mozilla.org/docs/Web/HTML/Element/input) element.
+   * @deprecated
+   */
   usemap?: string | undefined;
-  /** @deprecated */
+  /**
+   * `x-moz-errormessage` is an attribute of the [`input`](https://developer.mozilla.org/docs/Web/HTML/Element/input) element.
+   * @deprecated
+   */
   "x-moz-errormessage"?: string | undefined;
 }
 
@@ -46,6 +84,6 @@ export interface InputProps extends GlobalAttributes {
  * input renders the [`input`](https://developer.mozilla.org/docs/Web/HTML/Element/input) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/input>
  */
-export function input(props?: InputProps): string {
+export function input(props?: InputElementProps): string {
   return renderElement("input", props as AnyProps, true);
 }

--- a/ins.ts
+++ b/ins.ts
@@ -2,11 +2,13 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * InsProps are the props for the [`ins`](https://developer.mozilla.org/docs/Web/HTML/Element/ins) element.
+ * InsElementProps are the props for the [`ins`](https://developer.mozilla.org/docs/Web/HTML/Element/ins) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/ins>
  */
-export interface InsProps extends GlobalAttributes {
+export interface InsElementProps extends GlobalAttributes {
+  /** `cite` is an attribute of the [`ins`](https://developer.mozilla.org/docs/Web/HTML/Element/ins) element. */
   cite?: string | undefined;
+  /** `datetime` is an attribute of the [`ins`](https://developer.mozilla.org/docs/Web/HTML/Element/ins) element. */
   datetime?: string | undefined;
 }
 
@@ -14,6 +16,6 @@ export interface InsProps extends GlobalAttributes {
  * ins renders the [`ins`](https://developer.mozilla.org/docs/Web/HTML/Element/ins) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/ins>
  */
-export function ins(props?: InsProps, ...children: string[]): string {
+export function ins(props?: InsElementProps, ...children: string[]): string {
   return renderElement("ins", props as AnyProps, false, children);
 }

--- a/kbd.ts
+++ b/kbd.ts
@@ -2,9 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * KbdElementProps are the props for the [`kbd`](https://developer.mozilla.org/docs/Web/HTML/Element/kbd) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/kbd>
+ */
+export type KbdElementProps = GlobalAttributes;
+
+/**
  * kbd renders the [`kbd`](https://developer.mozilla.org/docs/Web/HTML/Element/kbd) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/kbd>
  */
-export function kbd(props?: GlobalAttributes, ...children: string[]): string {
+export function kbd(props?: KbdElementProps, ...children: string[]): string {
   return renderElement("kbd", props as AnyProps, false, children);
 }

--- a/kbd.ts
+++ b/kbd.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * KbdElementProps are the props for the [`kbd`](https://developer.mozilla.org/docs/Web/HTML/Element/kbd) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/kbd>
  */
-export type KbdElementProps = GlobalAttributes;
+export interface KbdElementProps extends GlobalAttributes {
+}
 
 /**
  * kbd renders the [`kbd`](https://developer.mozilla.org/docs/Web/HTML/Element/kbd) element.

--- a/label.ts
+++ b/label.ts
@@ -2,10 +2,11 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * LabelProps are the props for the [`label`](https://developer.mozilla.org/docs/Web/HTML/Element/label) element.
+ * LabelElementProps are the props for the [`label`](https://developer.mozilla.org/docs/Web/HTML/Element/label) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/label>
  */
-export interface LabelProps extends GlobalAttributes {
+export interface LabelElementProps extends GlobalAttributes {
+  /** `for` is an attribute of the [`label`](https://developer.mozilla.org/docs/Web/HTML/Element/label) element. */
   for?: string | undefined;
 }
 
@@ -13,6 +14,9 @@ export interface LabelProps extends GlobalAttributes {
  * label renders the [`label`](https://developer.mozilla.org/docs/Web/HTML/Element/label) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/label>
  */
-export function label(props?: LabelProps, ...children: string[]): string {
+export function label(
+  props?: LabelElementProps,
+  ...children: string[]
+): string {
   return renderElement("label", props as AnyProps, false, children);
 }

--- a/legend.ts
+++ b/legend.ts
@@ -2,11 +2,14 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * LegendProps are the props for the [`legend`](https://developer.mozilla.org/docs/Web/HTML/Element/legend) element.
+ * LegendElementProps are the props for the [`legend`](https://developer.mozilla.org/docs/Web/HTML/Element/legend) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/legend>
  */
-export interface LegendProps extends GlobalAttributes {
-  /** @deprecated */
+export interface LegendElementProps extends GlobalAttributes {
+  /**
+   * `align` is an attribute of the [`legend`](https://developer.mozilla.org/docs/Web/HTML/Element/legend) element.
+   * @deprecated
+   */
   align?: string | undefined;
 }
 
@@ -14,6 +17,9 @@ export interface LegendProps extends GlobalAttributes {
  * legend renders the [`legend`](https://developer.mozilla.org/docs/Web/HTML/Element/legend) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/legend>
  */
-export function legend(props?: LegendProps, ...children: string[]): string {
+export function legend(
+  props?: LegendElementProps,
+  ...children: string[]
+): string {
   return renderElement("legend", props as AnyProps, false, children);
 }

--- a/li.ts
+++ b/li.ts
@@ -2,12 +2,16 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * LiProps are the props for the [`li`](https://developer.mozilla.org/docs/Web/HTML/Element/li) element.
+ * LiElementProps are the props for the [`li`](https://developer.mozilla.org/docs/Web/HTML/Element/li) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/li>
  */
-export interface LiProps extends GlobalAttributes {
-  /** @deprecated */
+export interface LiElementProps extends GlobalAttributes {
+  /**
+   * `type` is an attribute of the [`li`](https://developer.mozilla.org/docs/Web/HTML/Element/li) element.
+   * @deprecated
+   */
   type?: string | undefined;
+  /** `value` is an attribute of the [`li`](https://developer.mozilla.org/docs/Web/HTML/Element/li) element. */
   value?: string | undefined;
 }
 
@@ -15,6 +19,6 @@ export interface LiProps extends GlobalAttributes {
  * li renders the [`li`](https://developer.mozilla.org/docs/Web/HTML/Element/li) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/li>
  */
-export function li(props?: LiProps, ...children: string[]): string {
+export function li(props?: LiElementProps, ...children: string[]): string {
   return renderElement("li", props as AnyProps, false, children);
 }

--- a/link.ts
+++ b/link.ts
@@ -2,33 +2,62 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * LinkProps are the props for the [`link`](https://developer.mozilla.org/docs/Web/HTML/Element/link) element.
+ * LinkElementProps are the props for the [`link`](https://developer.mozilla.org/docs/Web/HTML/Element/link) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/link>
  */
-export interface LinkProps extends GlobalAttributes {
+export interface LinkElementProps extends GlobalAttributes {
+  /** `as` is an attribute of the [`link`](https://developer.mozilla.org/docs/Web/HTML/Element/link) element. */
   as?: string | undefined;
-  /** @experimental */
+  /**
+   * `blocking` is an attribute of the [`link`](https://developer.mozilla.org/docs/Web/HTML/Element/link) element.
+   * @experimental
+   */
   blocking?: string | undefined;
-  /** @deprecated */
+  /**
+   * `charset` is an attribute of the [`link`](https://developer.mozilla.org/docs/Web/HTML/Element/link) element.
+   * @deprecated
+   */
   charset?: string | undefined;
+  /** `crossorigin` is an attribute of the [`link`](https://developer.mozilla.org/docs/Web/HTML/Element/link) element. */
   crossorigin?: string | undefined;
+  /** `disabled` is an attribute of the [`link`](https://developer.mozilla.org/docs/Web/HTML/Element/link) element. */
   disabled?: string | undefined;
+  /** `fetchpriority` is an attribute of the [`link`](https://developer.mozilla.org/docs/Web/HTML/Element/link) element. */
   fetchpriority?: string | undefined;
+  /** `href` is an attribute of the [`link`](https://developer.mozilla.org/docs/Web/HTML/Element/link) element. */
   href?: string | undefined;
+  /** `hreflang` is an attribute of the [`link`](https://developer.mozilla.org/docs/Web/HTML/Element/link) element. */
   hreflang?: string | undefined;
+  /** `imagesizes` is an attribute of the [`link`](https://developer.mozilla.org/docs/Web/HTML/Element/link) element. */
   imagesizes?: string | undefined;
+  /** `imagesrcset` is an attribute of the [`link`](https://developer.mozilla.org/docs/Web/HTML/Element/link) element. */
   imagesrcset?: string | undefined;
+  /** `integrity` is an attribute of the [`link`](https://developer.mozilla.org/docs/Web/HTML/Element/link) element. */
   integrity?: string | undefined;
+  /** `media` is an attribute of the [`link`](https://developer.mozilla.org/docs/Web/HTML/Element/link) element. */
   media?: string | undefined;
-  /** @deprecated */
+  /**
+   * `methods` is an attribute of the [`link`](https://developer.mozilla.org/docs/Web/HTML/Element/link) element.
+   * @deprecated
+   */
   methods?: string | undefined;
+  /** `referrerpolicy` is an attribute of the [`link`](https://developer.mozilla.org/docs/Web/HTML/Element/link) element. */
   referrerpolicy?: string | undefined;
+  /** `rel` is an attribute of the [`link`](https://developer.mozilla.org/docs/Web/HTML/Element/link) element. */
   rel?: string | undefined;
-  /** @deprecated */
+  /**
+   * `rev` is an attribute of the [`link`](https://developer.mozilla.org/docs/Web/HTML/Element/link) element.
+   * @deprecated
+   */
   rev?: string | undefined;
+  /** `sizes` is an attribute of the [`link`](https://developer.mozilla.org/docs/Web/HTML/Element/link) element. */
   sizes?: string | undefined;
-  /** @deprecated */
+  /**
+   * `target` is an attribute of the [`link`](https://developer.mozilla.org/docs/Web/HTML/Element/link) element.
+   * @deprecated
+   */
   target?: string | undefined;
+  /** `type` is an attribute of the [`link`](https://developer.mozilla.org/docs/Web/HTML/Element/link) element. */
   type?: string | undefined;
 }
 
@@ -36,6 +65,6 @@ export interface LinkProps extends GlobalAttributes {
  * link renders the [`link`](https://developer.mozilla.org/docs/Web/HTML/Element/link) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/link>
  */
-export function link(props?: LinkProps): string {
+export function link(props?: LinkElementProps): string {
   return renderElement("link", props as AnyProps, true);
 }

--- a/main.ts
+++ b/main.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * MainElementProps are the props for the [`main`](https://developer.mozilla.org/docs/Web/HTML/Element/main) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/main>
  */
-export type MainElementProps = GlobalAttributes;
+export interface MainElementProps extends GlobalAttributes {
+}
 
 /**
  * main renders the [`main`](https://developer.mozilla.org/docs/Web/HTML/Element/main) element.

--- a/main.ts
+++ b/main.ts
@@ -2,9 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * MainElementProps are the props for the [`main`](https://developer.mozilla.org/docs/Web/HTML/Element/main) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/main>
+ */
+export type MainElementProps = GlobalAttributes;
+
+/**
  * main renders the [`main`](https://developer.mozilla.org/docs/Web/HTML/Element/main) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/main>
  */
-export function main(props?: GlobalAttributes, ...children: string[]): string {
+export function main(props?: MainElementProps, ...children: string[]): string {
   return renderElement("main", props as AnyProps, false, children);
 }

--- a/map.ts
+++ b/map.ts
@@ -2,10 +2,11 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * MapProps are the props for the [`map`](https://developer.mozilla.org/docs/Web/HTML/Element/map) element.
+ * MapElementProps are the props for the [`map`](https://developer.mozilla.org/docs/Web/HTML/Element/map) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/map>
  */
-export interface MapProps extends GlobalAttributes {
+export interface MapElementProps extends GlobalAttributes {
+  /** `name` is an attribute of the [`map`](https://developer.mozilla.org/docs/Web/HTML/Element/map) element. */
   name?: string | undefined;
 }
 
@@ -13,6 +14,6 @@ export interface MapProps extends GlobalAttributes {
  * map renders the [`map`](https://developer.mozilla.org/docs/Web/HTML/Element/map) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/map>
  */
-export function map(props?: MapProps, ...children: string[]): string {
+export function map(props?: MapElementProps, ...children: string[]): string {
   return renderElement("map", props as AnyProps, false, children);
 }

--- a/mark.ts
+++ b/mark.ts
@@ -2,9 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * MarkElementProps are the props for the [`mark`](https://developer.mozilla.org/docs/Web/HTML/Element/mark) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/mark>
+ */
+export type MarkElementProps = GlobalAttributes;
+
+/**
  * mark renders the [`mark`](https://developer.mozilla.org/docs/Web/HTML/Element/mark) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/mark>
  */
-export function mark(props?: GlobalAttributes, ...children: string[]): string {
+export function mark(props?: MarkElementProps, ...children: string[]): string {
   return renderElement("mark", props as AnyProps, false, children);
 }

--- a/mark.ts
+++ b/mark.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * MarkElementProps are the props for the [`mark`](https://developer.mozilla.org/docs/Web/HTML/Element/mark) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/mark>
  */
-export type MarkElementProps = GlobalAttributes;
+export interface MarkElementProps extends GlobalAttributes {
+}
 
 /**
  * mark renders the [`mark`](https://developer.mozilla.org/docs/Web/HTML/Element/mark) element.

--- a/marquee.ts
+++ b/marquee.ts
@@ -2,32 +2,65 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * MarqueeProps are the props for the [`marquee`](https://developer.mozilla.org/docs/Web/HTML/Element/marquee) element.
+ * MarqueeElementProps are the props for the [`marquee`](https://developer.mozilla.org/docs/Web/HTML/Element/marquee) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/marquee>
  * @deprecated
  */
-export interface MarqueeProps extends GlobalAttributes {
-  /** @deprecated */
+export interface MarqueeElementProps extends GlobalAttributes {
+  /**
+   * `behavior` is an attribute of the [`marquee`](https://developer.mozilla.org/docs/Web/HTML/Element/marquee) element.
+   * @deprecated
+   */
   behavior?: string | undefined;
-  /** @deprecated */
+  /**
+   * `bgcolor` is an attribute of the [`marquee`](https://developer.mozilla.org/docs/Web/HTML/Element/marquee) element.
+   * @deprecated
+   */
   bgcolor?: string | undefined;
-  /** @deprecated */
+  /**
+   * `direction` is an attribute of the [`marquee`](https://developer.mozilla.org/docs/Web/HTML/Element/marquee) element.
+   * @deprecated
+   */
   direction?: string | undefined;
-  /** @deprecated */
+  /**
+   * `height` is an attribute of the [`marquee`](https://developer.mozilla.org/docs/Web/HTML/Element/marquee) element.
+   * @deprecated
+   */
   height?: string | undefined;
-  /** @deprecated */
+  /**
+   * `hspace` is an attribute of the [`marquee`](https://developer.mozilla.org/docs/Web/HTML/Element/marquee) element.
+   * @deprecated
+   */
   hspace?: string | undefined;
-  /** @deprecated */
+  /**
+   * `loop` is an attribute of the [`marquee`](https://developer.mozilla.org/docs/Web/HTML/Element/marquee) element.
+   * @deprecated
+   */
   loop?: string | undefined;
-  /** @deprecated */
+  /**
+   * `scrollamount` is an attribute of the [`marquee`](https://developer.mozilla.org/docs/Web/HTML/Element/marquee) element.
+   * @deprecated
+   */
   scrollamount?: string | undefined;
-  /** @deprecated */
+  /**
+   * `scrolldelay` is an attribute of the [`marquee`](https://developer.mozilla.org/docs/Web/HTML/Element/marquee) element.
+   * @deprecated
+   */
   scrolldelay?: string | undefined;
-  /** @deprecated */
+  /**
+   * `truespeed` is an attribute of the [`marquee`](https://developer.mozilla.org/docs/Web/HTML/Element/marquee) element.
+   * @deprecated
+   */
   truespeed?: string | undefined;
-  /** @deprecated */
+  /**
+   * `vspace` is an attribute of the [`marquee`](https://developer.mozilla.org/docs/Web/HTML/Element/marquee) element.
+   * @deprecated
+   */
   vspace?: string | undefined;
-  /** @deprecated */
+  /**
+   * `width` is an attribute of the [`marquee`](https://developer.mozilla.org/docs/Web/HTML/Element/marquee) element.
+   * @deprecated
+   */
   width?: string | undefined;
 }
 
@@ -36,6 +69,9 @@ export interface MarqueeProps extends GlobalAttributes {
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/marquee>
  * @deprecated
  */
-export function marquee(props?: MarqueeProps, ...children: string[]): string {
+export function marquee(
+  props?: MarqueeElementProps,
+  ...children: string[]
+): string {
   return renderElement("marquee", props as AnyProps, false, children);
 }

--- a/menu.ts
+++ b/menu.ts
@@ -2,11 +2,14 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * MenuProps are the props for the [`menu`](https://developer.mozilla.org/docs/Web/HTML/Element/menu) element.
+ * MenuElementProps are the props for the [`menu`](https://developer.mozilla.org/docs/Web/HTML/Element/menu) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/menu>
  */
-export interface MenuProps extends GlobalAttributes {
-  /** @deprecated */
+export interface MenuElementProps extends GlobalAttributes {
+  /**
+   * `label` is an attribute of the [`menu`](https://developer.mozilla.org/docs/Web/HTML/Element/menu) element.
+   * @deprecated
+   */
   label?: string | undefined;
 }
 
@@ -14,6 +17,6 @@ export interface MenuProps extends GlobalAttributes {
  * menu renders the [`menu`](https://developer.mozilla.org/docs/Web/HTML/Element/menu) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/menu>
  */
-export function menu(props?: MenuProps, ...children: string[]): string {
+export function menu(props?: MenuElementProps, ...children: string[]): string {
   return renderElement("menu", props as AnyProps, false, children);
 }

--- a/meta.ts
+++ b/meta.ts
@@ -2,15 +2,22 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * MetaProps are the props for the [`meta`](https://developer.mozilla.org/docs/Web/HTML/Element/meta) element.
+ * MetaElementProps are the props for the [`meta`](https://developer.mozilla.org/docs/Web/HTML/Element/meta) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/meta>
  */
-export interface MetaProps extends GlobalAttributes {
+export interface MetaElementProps extends GlobalAttributes {
+  /** `charset` is an attribute of the [`meta`](https://developer.mozilla.org/docs/Web/HTML/Element/meta) element. */
   charset?: string | undefined;
+  /** `content` is an attribute of the [`meta`](https://developer.mozilla.org/docs/Web/HTML/Element/meta) element. */
   content?: string | undefined;
+  /** `http-equiv` is an attribute of the [`meta`](https://developer.mozilla.org/docs/Web/HTML/Element/meta) element. */
   "http-equiv"?: string | undefined;
+  /** `name` is an attribute of the [`meta`](https://developer.mozilla.org/docs/Web/HTML/Element/meta) element. */
   name?: string | undefined;
-  /** @deprecated */
+  /**
+   * `scheme` is an attribute of the [`meta`](https://developer.mozilla.org/docs/Web/HTML/Element/meta) element.
+   * @deprecated
+   */
   scheme?: string | undefined;
 }
 
@@ -18,6 +25,6 @@ export interface MetaProps extends GlobalAttributes {
  * meta renders the [`meta`](https://developer.mozilla.org/docs/Web/HTML/Element/meta) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/meta>
  */
-export function meta(props?: MetaProps): string {
+export function meta(props?: MetaElementProps): string {
   return renderElement("meta", props as AnyProps, true);
 }

--- a/meter.ts
+++ b/meter.ts
@@ -2,15 +2,21 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * MeterProps are the props for the [`meter`](https://developer.mozilla.org/docs/Web/HTML/Element/meter) element.
+ * MeterElementProps are the props for the [`meter`](https://developer.mozilla.org/docs/Web/HTML/Element/meter) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/meter>
  */
-export interface MeterProps extends GlobalAttributes {
+export interface MeterElementProps extends GlobalAttributes {
+  /** `high` is an attribute of the [`meter`](https://developer.mozilla.org/docs/Web/HTML/Element/meter) element. */
   high?: string | undefined;
+  /** `low` is an attribute of the [`meter`](https://developer.mozilla.org/docs/Web/HTML/Element/meter) element. */
   low?: string | undefined;
+  /** `max` is an attribute of the [`meter`](https://developer.mozilla.org/docs/Web/HTML/Element/meter) element. */
   max?: string | undefined;
+  /** `min` is an attribute of the [`meter`](https://developer.mozilla.org/docs/Web/HTML/Element/meter) element. */
   min?: string | undefined;
+  /** `optimum` is an attribute of the [`meter`](https://developer.mozilla.org/docs/Web/HTML/Element/meter) element. */
   optimum?: string | undefined;
+  /** `value` is an attribute of the [`meter`](https://developer.mozilla.org/docs/Web/HTML/Element/meter) element. */
   value?: string | undefined;
 }
 
@@ -18,6 +24,9 @@ export interface MeterProps extends GlobalAttributes {
  * meter renders the [`meter`](https://developer.mozilla.org/docs/Web/HTML/Element/meter) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/meter>
  */
-export function meter(props?: MeterProps, ...children: string[]): string {
+export function meter(
+  props?: MeterElementProps,
+  ...children: string[]
+): string {
   return renderElement("meter", props as AnyProps, false, children);
 }

--- a/nav.ts
+++ b/nav.ts
@@ -2,9 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * NavElementProps are the props for the [`nav`](https://developer.mozilla.org/docs/Web/HTML/Element/nav) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/nav>
+ */
+export type NavElementProps = GlobalAttributes;
+
+/**
  * nav renders the [`nav`](https://developer.mozilla.org/docs/Web/HTML/Element/nav) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/nav>
  */
-export function nav(props?: GlobalAttributes, ...children: string[]): string {
+export function nav(props?: NavElementProps, ...children: string[]): string {
   return renderElement("nav", props as AnyProps, false, children);
 }

--- a/nav.ts
+++ b/nav.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * NavElementProps are the props for the [`nav`](https://developer.mozilla.org/docs/Web/HTML/Element/nav) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/nav>
  */
-export type NavElementProps = GlobalAttributes;
+export interface NavElementProps extends GlobalAttributes {
+}
 
 /**
  * nav renders the [`nav`](https://developer.mozilla.org/docs/Web/HTML/Element/nav) element.

--- a/nobr.ts
+++ b/nobr.ts
@@ -6,7 +6,8 @@ import { renderElement } from "./lib/mod.ts";
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/nobr>
  * @deprecated
  */
-export type NobrElementProps = GlobalAttributes;
+export interface NobrElementProps extends GlobalAttributes {
+}
 
 /**
  * nobr renders the [`nobr`](https://developer.mozilla.org/docs/Web/HTML/Element/nobr) element.

--- a/nobr.ts
+++ b/nobr.ts
@@ -2,10 +2,17 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * NobrElementProps are the props for the [`nobr`](https://developer.mozilla.org/docs/Web/HTML/Element/nobr) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/nobr>
+ * @deprecated
+ */
+export type NobrElementProps = GlobalAttributes;
+
+/**
  * nobr renders the [`nobr`](https://developer.mozilla.org/docs/Web/HTML/Element/nobr) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/nobr>
  * @deprecated
  */
-export function nobr(props?: GlobalAttributes, ...children: string[]): string {
+export function nobr(props?: NobrElementProps, ...children: string[]): string {
   return renderElement("nobr", props as AnyProps, false, children);
 }

--- a/noembed.ts
+++ b/noembed.ts
@@ -2,12 +2,19 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * NoembedElementProps are the props for the [`noembed`](https://developer.mozilla.org/docs/Web/HTML/Element/noembed) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/noembed>
+ * @deprecated
+ */
+export type NoembedElementProps = GlobalAttributes;
+
+/**
  * noembed renders the [`noembed`](https://developer.mozilla.org/docs/Web/HTML/Element/noembed) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/noembed>
  * @deprecated
  */
 export function noembed(
-  props?: GlobalAttributes,
+  props?: NoembedElementProps,
   ...children: string[]
 ): string {
   return renderElement("noembed", props as AnyProps, false, children);

--- a/noembed.ts
+++ b/noembed.ts
@@ -6,7 +6,8 @@ import { renderElement } from "./lib/mod.ts";
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/noembed>
  * @deprecated
  */
-export type NoembedElementProps = GlobalAttributes;
+export interface NoembedElementProps extends GlobalAttributes {
+}
 
 /**
  * noembed renders the [`noembed`](https://developer.mozilla.org/docs/Web/HTML/Element/noembed) element.

--- a/noframes.ts
+++ b/noframes.ts
@@ -6,7 +6,8 @@ import { renderElement } from "./lib/mod.ts";
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/noframes>
  * @deprecated
  */
-export type NoframesElementProps = GlobalAttributes;
+export interface NoframesElementProps extends GlobalAttributes {
+}
 
 /**
  * noframes renders the [`noframes`](https://developer.mozilla.org/docs/Web/HTML/Element/noframes) element.

--- a/noframes.ts
+++ b/noframes.ts
@@ -2,12 +2,19 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * NoframesElementProps are the props for the [`noframes`](https://developer.mozilla.org/docs/Web/HTML/Element/noframes) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/noframes>
+ * @deprecated
+ */
+export type NoframesElementProps = GlobalAttributes;
+
+/**
  * noframes renders the [`noframes`](https://developer.mozilla.org/docs/Web/HTML/Element/noframes) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/noframes>
  * @deprecated
  */
 export function noframes(
-  props?: GlobalAttributes,
+  props?: NoframesElementProps,
   ...children: string[]
 ): string {
   return renderElement("noframes", props as AnyProps, false, children);

--- a/noscript.ts
+++ b/noscript.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * NoscriptElementProps are the props for the [`noscript`](https://developer.mozilla.org/docs/Web/HTML/Element/noscript) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/noscript>
  */
-export type NoscriptElementProps = GlobalAttributes;
+export interface NoscriptElementProps extends GlobalAttributes {
+}
 
 /**
  * noscript renders the [`noscript`](https://developer.mozilla.org/docs/Web/HTML/Element/noscript) element.

--- a/noscript.ts
+++ b/noscript.ts
@@ -2,11 +2,17 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * NoscriptElementProps are the props for the [`noscript`](https://developer.mozilla.org/docs/Web/HTML/Element/noscript) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/noscript>
+ */
+export type NoscriptElementProps = GlobalAttributes;
+
+/**
  * noscript renders the [`noscript`](https://developer.mozilla.org/docs/Web/HTML/Element/noscript) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/noscript>
  */
 export function noscript(
-  props?: GlobalAttributes,
+  props?: NoscriptElementProps,
   ...children: string[]
 ): string {
   return renderElement("noscript", props as AnyProps, false, children);

--- a/object.ts
+++ b/object.ts
@@ -2,33 +2,66 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * ObjectProps are the props for the [`object`](https://developer.mozilla.org/docs/Web/HTML/Element/object) element.
+ * ObjectElementProps are the props for the [`object`](https://developer.mozilla.org/docs/Web/HTML/Element/object) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/object>
  */
-export interface ObjectProps extends GlobalAttributes {
-  /** @deprecated */
+export interface ObjectElementProps extends GlobalAttributes {
+  /**
+   * `archive` is an attribute of the [`object`](https://developer.mozilla.org/docs/Web/HTML/Element/object) element.
+   * @deprecated
+   */
   archive?: string | undefined;
-  /** @deprecated */
+  /**
+   * `border` is an attribute of the [`object`](https://developer.mozilla.org/docs/Web/HTML/Element/object) element.
+   * @deprecated
+   */
   border?: string | undefined;
-  /** @deprecated */
+  /**
+   * `classid` is an attribute of the [`object`](https://developer.mozilla.org/docs/Web/HTML/Element/object) element.
+   * @deprecated
+   */
   classid?: string | undefined;
-  /** @deprecated */
+  /**
+   * `codebase` is an attribute of the [`object`](https://developer.mozilla.org/docs/Web/HTML/Element/object) element.
+   * @deprecated
+   */
   codebase?: string | undefined;
-  /** @deprecated */
+  /**
+   * `codetype` is an attribute of the [`object`](https://developer.mozilla.org/docs/Web/HTML/Element/object) element.
+   * @deprecated
+   */
   codetype?: string | undefined;
+  /** `data` is an attribute of the [`object`](https://developer.mozilla.org/docs/Web/HTML/Element/object) element. */
   data?: string | undefined;
-  /** @deprecated */
+  /**
+   * `declare` is an attribute of the [`object`](https://developer.mozilla.org/docs/Web/HTML/Element/object) element.
+   * @deprecated
+   */
   declare?: string | undefined;
+  /** `form` is an attribute of the [`object`](https://developer.mozilla.org/docs/Web/HTML/Element/object) element. */
   form?: string | undefined;
+  /** `height` is an attribute of the [`object`](https://developer.mozilla.org/docs/Web/HTML/Element/object) element. */
   height?: string | undefined;
+  /** `name` is an attribute of the [`object`](https://developer.mozilla.org/docs/Web/HTML/Element/object) element. */
   name?: string | undefined;
-  /** @deprecated */
+  /**
+   * `standby` is an attribute of the [`object`](https://developer.mozilla.org/docs/Web/HTML/Element/object) element.
+   * @deprecated
+   */
   standby?: string | undefined;
-  /** @deprecated */
+  /**
+   * `tabindex` is an attribute of the [`object`](https://developer.mozilla.org/docs/Web/HTML/Element/object) element.
+   * @deprecated
+   */
   tabindex?: string | undefined;
+  /** `type` is an attribute of the [`object`](https://developer.mozilla.org/docs/Web/HTML/Element/object) element. */
   type?: string | undefined;
-  /** @deprecated */
+  /**
+   * `usemap` is an attribute of the [`object`](https://developer.mozilla.org/docs/Web/HTML/Element/object) element.
+   * @deprecated
+   */
   usemap?: string | undefined;
+  /** `width` is an attribute of the [`object`](https://developer.mozilla.org/docs/Web/HTML/Element/object) element. */
   width?: string | undefined;
 }
 
@@ -36,6 +69,9 @@ export interface ObjectProps extends GlobalAttributes {
  * object renders the [`object`](https://developer.mozilla.org/docs/Web/HTML/Element/object) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/object>
  */
-export function object(props?: ObjectProps, ...children: string[]): string {
+export function object(
+  props?: ObjectElementProps,
+  ...children: string[]
+): string {
   return renderElement("object", props as AnyProps, false, children);
 }

--- a/ol.ts
+++ b/ol.ts
@@ -2,14 +2,20 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * OlProps are the props for the [`ol`](https://developer.mozilla.org/docs/Web/HTML/Element/ol) element.
+ * OlElementProps are the props for the [`ol`](https://developer.mozilla.org/docs/Web/HTML/Element/ol) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/ol>
  */
-export interface OlProps extends GlobalAttributes {
-  /** @deprecated */
+export interface OlElementProps extends GlobalAttributes {
+  /**
+   * `compact` is an attribute of the [`ol`](https://developer.mozilla.org/docs/Web/HTML/Element/ol) element.
+   * @deprecated
+   */
   compact?: string | undefined;
+  /** `reversed` is an attribute of the [`ol`](https://developer.mozilla.org/docs/Web/HTML/Element/ol) element. */
   reversed?: string | undefined;
+  /** `start` is an attribute of the [`ol`](https://developer.mozilla.org/docs/Web/HTML/Element/ol) element. */
   start?: string | undefined;
+  /** `type` is an attribute of the [`ol`](https://developer.mozilla.org/docs/Web/HTML/Element/ol) element. */
   type?: string | undefined;
 }
 
@@ -17,6 +23,6 @@ export interface OlProps extends GlobalAttributes {
  * ol renders the [`ol`](https://developer.mozilla.org/docs/Web/HTML/Element/ol) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/ol>
  */
-export function ol(props?: OlProps, ...children: string[]): string {
+export function ol(props?: OlElementProps, ...children: string[]): string {
   return renderElement("ol", props as AnyProps, false, children);
 }

--- a/optgroup.ts
+++ b/optgroup.ts
@@ -2,11 +2,13 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * OptgroupProps are the props for the [`optgroup`](https://developer.mozilla.org/docs/Web/HTML/Element/optgroup) element.
+ * OptgroupElementProps are the props for the [`optgroup`](https://developer.mozilla.org/docs/Web/HTML/Element/optgroup) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/optgroup>
  */
-export interface OptgroupProps extends GlobalAttributes {
+export interface OptgroupElementProps extends GlobalAttributes {
+  /** `disabled` is an attribute of the [`optgroup`](https://developer.mozilla.org/docs/Web/HTML/Element/optgroup) element. */
   disabled?: string | undefined;
+  /** `label` is an attribute of the [`optgroup`](https://developer.mozilla.org/docs/Web/HTML/Element/optgroup) element. */
   label?: string | undefined;
 }
 
@@ -14,6 +16,9 @@ export interface OptgroupProps extends GlobalAttributes {
  * optgroup renders the [`optgroup`](https://developer.mozilla.org/docs/Web/HTML/Element/optgroup) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/optgroup>
  */
-export function optgroup(props?: OptgroupProps, ...children: string[]): string {
+export function optgroup(
+  props?: OptgroupElementProps,
+  ...children: string[]
+): string {
   return renderElement("optgroup", props as AnyProps, false, children);
 }

--- a/option.ts
+++ b/option.ts
@@ -2,13 +2,17 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * OptionProps are the props for the [`option`](https://developer.mozilla.org/docs/Web/HTML/Element/option) element.
+ * OptionElementProps are the props for the [`option`](https://developer.mozilla.org/docs/Web/HTML/Element/option) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/option>
  */
-export interface OptionProps extends GlobalAttributes {
+export interface OptionElementProps extends GlobalAttributes {
+  /** `disabled` is an attribute of the [`option`](https://developer.mozilla.org/docs/Web/HTML/Element/option) element. */
   disabled?: string | undefined;
+  /** `label` is an attribute of the [`option`](https://developer.mozilla.org/docs/Web/HTML/Element/option) element. */
   label?: string | undefined;
+  /** `selected` is an attribute of the [`option`](https://developer.mozilla.org/docs/Web/HTML/Element/option) element. */
   selected?: string | undefined;
+  /** `value` is an attribute of the [`option`](https://developer.mozilla.org/docs/Web/HTML/Element/option) element. */
   value?: string | undefined;
 }
 
@@ -16,6 +20,9 @@ export interface OptionProps extends GlobalAttributes {
  * option renders the [`option`](https://developer.mozilla.org/docs/Web/HTML/Element/option) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/option>
  */
-export function option(props?: OptionProps, ...children: string[]): string {
+export function option(
+  props?: OptionElementProps,
+  ...children: string[]
+): string {
   return renderElement("option", props as AnyProps, false, children);
 }

--- a/output.ts
+++ b/output.ts
@@ -2,12 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * OutputProps are the props for the [`output`](https://developer.mozilla.org/docs/Web/HTML/Element/output) element.
+ * OutputElementProps are the props for the [`output`](https://developer.mozilla.org/docs/Web/HTML/Element/output) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/output>
  */
-export interface OutputProps extends GlobalAttributes {
+export interface OutputElementProps extends GlobalAttributes {
+  /** `for` is an attribute of the [`output`](https://developer.mozilla.org/docs/Web/HTML/Element/output) element. */
   for?: string | undefined;
+  /** `form` is an attribute of the [`output`](https://developer.mozilla.org/docs/Web/HTML/Element/output) element. */
   form?: string | undefined;
+  /** `name` is an attribute of the [`output`](https://developer.mozilla.org/docs/Web/HTML/Element/output) element. */
   name?: string | undefined;
 }
 
@@ -15,6 +18,9 @@ export interface OutputProps extends GlobalAttributes {
  * output renders the [`output`](https://developer.mozilla.org/docs/Web/HTML/Element/output) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/output>
  */
-export function output(props?: OutputProps, ...children: string[]): string {
+export function output(
+  props?: OutputElementProps,
+  ...children: string[]
+): string {
   return renderElement("output", props as AnyProps, false, children);
 }

--- a/p.ts
+++ b/p.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * PElementProps are the props for the [`p`](https://developer.mozilla.org/docs/Web/HTML/Element/p) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/p>
  */
-export type PElementProps = GlobalAttributes;
+export interface PElementProps extends GlobalAttributes {
+}
 
 /**
  * p renders the [`p`](https://developer.mozilla.org/docs/Web/HTML/Element/p) element.

--- a/p.ts
+++ b/p.ts
@@ -2,9 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * PElementProps are the props for the [`p`](https://developer.mozilla.org/docs/Web/HTML/Element/p) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/p>
+ */
+export type PElementProps = GlobalAttributes;
+
+/**
  * p renders the [`p`](https://developer.mozilla.org/docs/Web/HTML/Element/p) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/p>
  */
-export function p(props?: GlobalAttributes, ...children: string[]): string {
+export function p(props?: PElementProps, ...children: string[]): string {
   return renderElement("p", props as AnyProps, false, children);
 }

--- a/param.ts
+++ b/param.ts
@@ -2,18 +2,30 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * ParamProps are the props for the [`param`](https://developer.mozilla.org/docs/Web/HTML/Element/param) element.
+ * ParamElementProps are the props for the [`param`](https://developer.mozilla.org/docs/Web/HTML/Element/param) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/param>
  * @deprecated
  */
-export interface ParamProps extends GlobalAttributes {
-  /** @deprecated */
+export interface ParamElementProps extends GlobalAttributes {
+  /**
+   * `name` is an attribute of the [`param`](https://developer.mozilla.org/docs/Web/HTML/Element/param) element.
+   * @deprecated
+   */
   name?: string | undefined;
-  /** @deprecated */
+  /**
+   * `type` is an attribute of the [`param`](https://developer.mozilla.org/docs/Web/HTML/Element/param) element.
+   * @deprecated
+   */
   type?: string | undefined;
-  /** @deprecated */
+  /**
+   * `value` is an attribute of the [`param`](https://developer.mozilla.org/docs/Web/HTML/Element/param) element.
+   * @deprecated
+   */
   value?: string | undefined;
-  /** @deprecated */
+  /**
+   * `valuetype` is an attribute of the [`param`](https://developer.mozilla.org/docs/Web/HTML/Element/param) element.
+   * @deprecated
+   */
   valuetype?: string | undefined;
 }
 
@@ -22,6 +34,6 @@ export interface ParamProps extends GlobalAttributes {
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/param>
  * @deprecated
  */
-export function param(props?: ParamProps): string {
+export function param(props?: ParamElementProps): string {
   return renderElement("param", props as AnyProps, true);
 }

--- a/picture.ts
+++ b/picture.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * PictureElementProps are the props for the [`picture`](https://developer.mozilla.org/docs/Web/HTML/Element/picture) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/picture>
  */
-export type PictureElementProps = GlobalAttributes;
+export interface PictureElementProps extends GlobalAttributes {
+}
 
 /**
  * picture renders the [`picture`](https://developer.mozilla.org/docs/Web/HTML/Element/picture) element.

--- a/picture.ts
+++ b/picture.ts
@@ -2,11 +2,17 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * PictureElementProps are the props for the [`picture`](https://developer.mozilla.org/docs/Web/HTML/Element/picture) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/picture>
+ */
+export type PictureElementProps = GlobalAttributes;
+
+/**
  * picture renders the [`picture`](https://developer.mozilla.org/docs/Web/HTML/Element/picture) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/picture>
  */
 export function picture(
-  props?: GlobalAttributes,
+  props?: PictureElementProps,
   ...children: string[]
 ): string {
   return renderElement("picture", props as AnyProps, false, children);

--- a/plaintext.ts
+++ b/plaintext.ts
@@ -6,7 +6,8 @@ import { renderElement } from "./lib/mod.ts";
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/plaintext>
  * @deprecated
  */
-export type PlaintextElementProps = GlobalAttributes;
+export interface PlaintextElementProps extends GlobalAttributes {
+}
 
 /**
  * plaintext renders the [`plaintext`](https://developer.mozilla.org/docs/Web/HTML/Element/plaintext) element.

--- a/plaintext.ts
+++ b/plaintext.ts
@@ -2,12 +2,19 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * PlaintextElementProps are the props for the [`plaintext`](https://developer.mozilla.org/docs/Web/HTML/Element/plaintext) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/plaintext>
+ * @deprecated
+ */
+export type PlaintextElementProps = GlobalAttributes;
+
+/**
  * plaintext renders the [`plaintext`](https://developer.mozilla.org/docs/Web/HTML/Element/plaintext) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/plaintext>
  * @deprecated
  */
 export function plaintext(
-  props?: GlobalAttributes,
+  props?: PlaintextElementProps,
   ...children: string[]
 ): string {
   return renderElement("plaintext", props as AnyProps, false, children);

--- a/portal.ts
+++ b/portal.ts
@@ -6,7 +6,8 @@ import { renderElement } from "./lib/mod.ts";
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/portal>
  * @experimental
  */
-export type PortalElementProps = GlobalAttributes;
+export interface PortalElementProps extends GlobalAttributes {
+}
 
 /**
  * portal renders the [`portal`](https://developer.mozilla.org/docs/Web/HTML/Element/portal) element.

--- a/portal.ts
+++ b/portal.ts
@@ -2,12 +2,19 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * PortalElementProps are the props for the [`portal`](https://developer.mozilla.org/docs/Web/HTML/Element/portal) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/portal>
+ * @experimental
+ */
+export type PortalElementProps = GlobalAttributes;
+
+/**
  * portal renders the [`portal`](https://developer.mozilla.org/docs/Web/HTML/Element/portal) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/portal>
  * @experimental
  */
 export function portal(
-  props?: GlobalAttributes,
+  props?: PortalElementProps,
   ...children: string[]
 ): string {
   return renderElement("portal", props as AnyProps, false, children);

--- a/pre.ts
+++ b/pre.ts
@@ -2,15 +2,24 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * PreProps are the props for the [`pre`](https://developer.mozilla.org/docs/Web/HTML/Element/pre) element.
+ * PreElementProps are the props for the [`pre`](https://developer.mozilla.org/docs/Web/HTML/Element/pre) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/pre>
  */
-export interface PreProps extends GlobalAttributes {
-  /** @deprecated */
+export interface PreElementProps extends GlobalAttributes {
+  /**
+   * `cols` is an attribute of the [`pre`](https://developer.mozilla.org/docs/Web/HTML/Element/pre) element.
+   * @deprecated
+   */
   cols?: string | undefined;
-  /** @deprecated */
+  /**
+   * `width` is an attribute of the [`pre`](https://developer.mozilla.org/docs/Web/HTML/Element/pre) element.
+   * @deprecated
+   */
   width?: string | undefined;
-  /** @deprecated */
+  /**
+   * `wrap` is an attribute of the [`pre`](https://developer.mozilla.org/docs/Web/HTML/Element/pre) element.
+   * @deprecated
+   */
   wrap?: string | undefined;
 }
 
@@ -18,6 +27,6 @@ export interface PreProps extends GlobalAttributes {
  * pre renders the [`pre`](https://developer.mozilla.org/docs/Web/HTML/Element/pre) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/pre>
  */
-export function pre(props?: PreProps, ...children: string[]): string {
+export function pre(props?: PreElementProps, ...children: string[]): string {
   return renderElement("pre", props as AnyProps, false, children);
 }

--- a/progress.ts
+++ b/progress.ts
@@ -2,11 +2,13 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * ProgressProps are the props for the [`progress`](https://developer.mozilla.org/docs/Web/HTML/Element/progress) element.
+ * ProgressElementProps are the props for the [`progress`](https://developer.mozilla.org/docs/Web/HTML/Element/progress) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/progress>
  */
-export interface ProgressProps extends GlobalAttributes {
+export interface ProgressElementProps extends GlobalAttributes {
+  /** `max` is an attribute of the [`progress`](https://developer.mozilla.org/docs/Web/HTML/Element/progress) element. */
   max?: string | undefined;
+  /** `value` is an attribute of the [`progress`](https://developer.mozilla.org/docs/Web/HTML/Element/progress) element. */
   value?: string | undefined;
 }
 
@@ -14,6 +16,9 @@ export interface ProgressProps extends GlobalAttributes {
  * progress renders the [`progress`](https://developer.mozilla.org/docs/Web/HTML/Element/progress) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/progress>
  */
-export function progress(props?: ProgressProps, ...children: string[]): string {
+export function progress(
+  props?: ProgressElementProps,
+  ...children: string[]
+): string {
   return renderElement("progress", props as AnyProps, false, children);
 }

--- a/q.ts
+++ b/q.ts
@@ -2,10 +2,11 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * QProps are the props for the [`q`](https://developer.mozilla.org/docs/Web/HTML/Element/q) element.
+ * QElementProps are the props for the [`q`](https://developer.mozilla.org/docs/Web/HTML/Element/q) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/q>
  */
-export interface QProps extends GlobalAttributes {
+export interface QElementProps extends GlobalAttributes {
+  /** `cite` is an attribute of the [`q`](https://developer.mozilla.org/docs/Web/HTML/Element/q) element. */
   cite?: string | undefined;
 }
 
@@ -13,6 +14,6 @@ export interface QProps extends GlobalAttributes {
  * q renders the [`q`](https://developer.mozilla.org/docs/Web/HTML/Element/q) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/q>
  */
-export function q(props?: QProps, ...children: string[]): string {
+export function q(props?: QElementProps, ...children: string[]): string {
   return renderElement("q", props as AnyProps, false, children);
 }

--- a/rb.ts
+++ b/rb.ts
@@ -6,7 +6,8 @@ import { renderElement } from "./lib/mod.ts";
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/rb>
  * @deprecated
  */
-export type RbElementProps = GlobalAttributes;
+export interface RbElementProps extends GlobalAttributes {
+}
 
 /**
  * rb renders the [`rb`](https://developer.mozilla.org/docs/Web/HTML/Element/rb) element.

--- a/rb.ts
+++ b/rb.ts
@@ -2,10 +2,17 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * RbElementProps are the props for the [`rb`](https://developer.mozilla.org/docs/Web/HTML/Element/rb) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/rb>
+ * @deprecated
+ */
+export type RbElementProps = GlobalAttributes;
+
+/**
  * rb renders the [`rb`](https://developer.mozilla.org/docs/Web/HTML/Element/rb) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/rb>
  * @deprecated
  */
-export function rb(props?: GlobalAttributes, ...children: string[]): string {
+export function rb(props?: RbElementProps, ...children: string[]): string {
   return renderElement("rb", props as AnyProps, false, children);
 }

--- a/rp.ts
+++ b/rp.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * RpElementProps are the props for the [`rp`](https://developer.mozilla.org/docs/Web/HTML/Element/rp) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/rp>
  */
-export type RpElementProps = GlobalAttributes;
+export interface RpElementProps extends GlobalAttributes {
+}
 
 /**
  * rp renders the [`rp`](https://developer.mozilla.org/docs/Web/HTML/Element/rp) element.

--- a/rp.ts
+++ b/rp.ts
@@ -2,9 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * RpElementProps are the props for the [`rp`](https://developer.mozilla.org/docs/Web/HTML/Element/rp) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/rp>
+ */
+export type RpElementProps = GlobalAttributes;
+
+/**
  * rp renders the [`rp`](https://developer.mozilla.org/docs/Web/HTML/Element/rp) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/rp>
  */
-export function rp(props?: GlobalAttributes, ...children: string[]): string {
+export function rp(props?: RpElementProps, ...children: string[]): string {
   return renderElement("rp", props as AnyProps, false, children);
 }

--- a/rt.ts
+++ b/rt.ts
@@ -2,9 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * RtElementProps are the props for the [`rt`](https://developer.mozilla.org/docs/Web/HTML/Element/rt) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/rt>
+ */
+export type RtElementProps = GlobalAttributes;
+
+/**
  * rt renders the [`rt`](https://developer.mozilla.org/docs/Web/HTML/Element/rt) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/rt>
  */
-export function rt(props?: GlobalAttributes, ...children: string[]): string {
+export function rt(props?: RtElementProps, ...children: string[]): string {
   return renderElement("rt", props as AnyProps, false, children);
 }

--- a/rt.ts
+++ b/rt.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * RtElementProps are the props for the [`rt`](https://developer.mozilla.org/docs/Web/HTML/Element/rt) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/rt>
  */
-export type RtElementProps = GlobalAttributes;
+export interface RtElementProps extends GlobalAttributes {
+}
 
 /**
  * rt renders the [`rt`](https://developer.mozilla.org/docs/Web/HTML/Element/rt) element.

--- a/rtc.ts
+++ b/rtc.ts
@@ -6,7 +6,8 @@ import { renderElement } from "./lib/mod.ts";
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/rtc>
  * @deprecated
  */
-export type RtcElementProps = GlobalAttributes;
+export interface RtcElementProps extends GlobalAttributes {
+}
 
 /**
  * rtc renders the [`rtc`](https://developer.mozilla.org/docs/Web/HTML/Element/rtc) element.

--- a/rtc.ts
+++ b/rtc.ts
@@ -2,10 +2,17 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * RtcElementProps are the props for the [`rtc`](https://developer.mozilla.org/docs/Web/HTML/Element/rtc) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/rtc>
+ * @deprecated
+ */
+export type RtcElementProps = GlobalAttributes;
+
+/**
  * rtc renders the [`rtc`](https://developer.mozilla.org/docs/Web/HTML/Element/rtc) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/rtc>
  * @deprecated
  */
-export function rtc(props?: GlobalAttributes, ...children: string[]): string {
+export function rtc(props?: RtcElementProps, ...children: string[]): string {
   return renderElement("rtc", props as AnyProps, false, children);
 }

--- a/ruby.ts
+++ b/ruby.ts
@@ -2,9 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * RubyElementProps are the props for the [`ruby`](https://developer.mozilla.org/docs/Web/HTML/Element/ruby) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/ruby>
+ */
+export type RubyElementProps = GlobalAttributes;
+
+/**
  * ruby renders the [`ruby`](https://developer.mozilla.org/docs/Web/HTML/Element/ruby) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/ruby>
  */
-export function ruby(props?: GlobalAttributes, ...children: string[]): string {
+export function ruby(props?: RubyElementProps, ...children: string[]): string {
   return renderElement("ruby", props as AnyProps, false, children);
 }

--- a/ruby.ts
+++ b/ruby.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * RubyElementProps are the props for the [`ruby`](https://developer.mozilla.org/docs/Web/HTML/Element/ruby) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/ruby>
  */
-export type RubyElementProps = GlobalAttributes;
+export interface RubyElementProps extends GlobalAttributes {
+}
 
 /**
  * ruby renders the [`ruby`](https://developer.mozilla.org/docs/Web/HTML/Element/ruby) element.

--- a/s.ts
+++ b/s.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * SElementProps are the props for the [`s`](https://developer.mozilla.org/docs/Web/HTML/Element/s) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/s>
  */
-export interface SElementProps extends GlobalAttributes {}
+export interface SElementProps extends GlobalAttributes {
+}
 
 /**
  * s renders the [`s`](https://developer.mozilla.org/docs/Web/HTML/Element/s) element.

--- a/s.ts
+++ b/s.ts
@@ -2,9 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * SElementProps are the props for the [`s`](https://developer.mozilla.org/docs/Web/HTML/Element/s) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/s>
+ */
+export interface SElementProps extends GlobalAttributes {}
+
+/**
  * s renders the [`s`](https://developer.mozilla.org/docs/Web/HTML/Element/s) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/s>
  */
-export function s(props?: GlobalAttributes, ...children: string[]): string {
+export function s(props?: SElementProps, ...children: string[]): string {
   return renderElement("s", props as AnyProps, false, children);
 }

--- a/samp.ts
+++ b/samp.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * SampElementProps are the props for the [`samp`](https://developer.mozilla.org/docs/Web/HTML/Element/samp) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/samp>
  */
-export type SampElementProps = GlobalAttributes;
+export interface SampElementProps extends GlobalAttributes {
+}
 
 /**
  * samp renders the [`samp`](https://developer.mozilla.org/docs/Web/HTML/Element/samp) element.

--- a/samp.ts
+++ b/samp.ts
@@ -2,9 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * SampElementProps are the props for the [`samp`](https://developer.mozilla.org/docs/Web/HTML/Element/samp) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/samp>
+ */
+export type SampElementProps = GlobalAttributes;
+
+/**
  * samp renders the [`samp`](https://developer.mozilla.org/docs/Web/HTML/Element/samp) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/samp>
  */
-export function samp(props?: GlobalAttributes, ...children: string[]): string {
+export function samp(props?: SampElementProps, ...children: string[]): string {
   return renderElement("samp", props as AnyProps, false, children);
 }

--- a/script.ts
+++ b/script.ts
@@ -2,22 +2,37 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * ScriptProps are the props for the [`script`](https://developer.mozilla.org/docs/Web/HTML/Element/script) element.
+ * ScriptElementProps are the props for the [`script`](https://developer.mozilla.org/docs/Web/HTML/Element/script) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/script>
  */
-export interface ScriptProps extends GlobalAttributes {
+export interface ScriptElementProps extends GlobalAttributes {
+  /** `async` is an attribute of the [`script`](https://developer.mozilla.org/docs/Web/HTML/Element/script) element. */
   async?: string | undefined;
-  /** @experimental */
+  /**
+   * `attributionsrc` is an attribute of the [`script`](https://developer.mozilla.org/docs/Web/HTML/Element/script) element.
+   * @experimental
+   */
   attributionsrc?: string | undefined;
-  /** @experimental */
+  /**
+   * `blocking` is an attribute of the [`script`](https://developer.mozilla.org/docs/Web/HTML/Element/script) element.
+   * @experimental
+   */
   blocking?: string | undefined;
+  /** `crossorigin` is an attribute of the [`script`](https://developer.mozilla.org/docs/Web/HTML/Element/script) element. */
   crossorigin?: string | undefined;
+  /** `defer` is an attribute of the [`script`](https://developer.mozilla.org/docs/Web/HTML/Element/script) element. */
   defer?: string | undefined;
+  /** `fetchpriority` is an attribute of the [`script`](https://developer.mozilla.org/docs/Web/HTML/Element/script) element. */
   fetchpriority?: string | undefined;
+  /** `integrity` is an attribute of the [`script`](https://developer.mozilla.org/docs/Web/HTML/Element/script) element. */
   integrity?: string | undefined;
+  /** `nomodule` is an attribute of the [`script`](https://developer.mozilla.org/docs/Web/HTML/Element/script) element. */
   nomodule?: string | undefined;
+  /** `referrerpolicy` is an attribute of the [`script`](https://developer.mozilla.org/docs/Web/HTML/Element/script) element. */
   referrerpolicy?: string | undefined;
+  /** `src` is an attribute of the [`script`](https://developer.mozilla.org/docs/Web/HTML/Element/script) element. */
   src?: string | undefined;
+  /** `type` is an attribute of the [`script`](https://developer.mozilla.org/docs/Web/HTML/Element/script) element. */
   type?: string | undefined;
 }
 
@@ -25,6 +40,9 @@ export interface ScriptProps extends GlobalAttributes {
  * script renders the [`script`](https://developer.mozilla.org/docs/Web/HTML/Element/script) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/script>
  */
-export function script(props?: ScriptProps, ...children: string[]): string {
+export function script(
+  props?: ScriptElementProps,
+  ...children: string[]
+): string {
   return renderElement("script", props as AnyProps, false, children);
 }

--- a/search.ts
+++ b/search.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * SearchElementProps are the props for the [`search`](https://developer.mozilla.org/docs/Web/HTML/Element/search) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/search>
  */
-export type SearchElementProps = GlobalAttributes;
+export interface SearchElementProps extends GlobalAttributes {
+}
 
 /**
  * search renders the [`search`](https://developer.mozilla.org/docs/Web/HTML/Element/search) element.

--- a/search.ts
+++ b/search.ts
@@ -2,11 +2,17 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * SearchElementProps are the props for the [`search`](https://developer.mozilla.org/docs/Web/HTML/Element/search) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/search>
+ */
+export type SearchElementProps = GlobalAttributes;
+
+/**
  * search renders the [`search`](https://developer.mozilla.org/docs/Web/HTML/Element/search) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/search>
  */
 export function search(
-  props?: GlobalAttributes,
+  props?: SearchElementProps,
   ...children: string[]
 ): string {
   return renderElement("search", props as AnyProps, false, children);

--- a/section.ts
+++ b/section.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * SectionElementProps are the props for the [`section`](https://developer.mozilla.org/docs/Web/HTML/Element/section) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/section>
  */
-export type SectionElementProps = GlobalAttributes;
+export interface SectionElementProps extends GlobalAttributes {
+}
 
 /**
  * section renders the [`section`](https://developer.mozilla.org/docs/Web/HTML/Element/section) element.

--- a/section.ts
+++ b/section.ts
@@ -2,11 +2,17 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * SectionElementProps are the props for the [`section`](https://developer.mozilla.org/docs/Web/HTML/Element/section) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/section>
+ */
+export type SectionElementProps = GlobalAttributes;
+
+/**
  * section renders the [`section`](https://developer.mozilla.org/docs/Web/HTML/Element/section) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/section>
  */
 export function section(
-  props?: GlobalAttributes,
+  props?: SectionElementProps,
   ...children: string[]
 ): string {
   return renderElement("section", props as AnyProps, false, children);

--- a/select.ts
+++ b/select.ts
@@ -2,15 +2,21 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * SelectProps are the props for the [`select`](https://developer.mozilla.org/docs/Web/HTML/Element/select) element.
+ * SelectElementProps are the props for the [`select`](https://developer.mozilla.org/docs/Web/HTML/Element/select) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/select>
  */
-export interface SelectProps extends GlobalAttributes {
+export interface SelectElementProps extends GlobalAttributes {
+  /** `disabled` is an attribute of the [`select`](https://developer.mozilla.org/docs/Web/HTML/Element/select) element. */
   disabled?: string | undefined;
+  /** `form` is an attribute of the [`select`](https://developer.mozilla.org/docs/Web/HTML/Element/select) element. */
   form?: string | undefined;
+  /** `multiple` is an attribute of the [`select`](https://developer.mozilla.org/docs/Web/HTML/Element/select) element. */
   multiple?: string | undefined;
+  /** `name` is an attribute of the [`select`](https://developer.mozilla.org/docs/Web/HTML/Element/select) element. */
   name?: string | undefined;
+  /** `required` is an attribute of the [`select`](https://developer.mozilla.org/docs/Web/HTML/Element/select) element. */
   required?: string | undefined;
+  /** `size` is an attribute of the [`select`](https://developer.mozilla.org/docs/Web/HTML/Element/select) element. */
   size?: string | undefined;
 }
 
@@ -18,6 +24,9 @@ export interface SelectProps extends GlobalAttributes {
  * select renders the [`select`](https://developer.mozilla.org/docs/Web/HTML/Element/select) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/select>
  */
-export function select(props?: SelectProps, ...children: string[]): string {
+export function select(
+  props?: SelectElementProps,
+  ...children: string[]
+): string {
   return renderElement("select", props as AnyProps, false, children);
 }

--- a/slot.ts
+++ b/slot.ts
@@ -2,10 +2,11 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * SlotProps are the props for the [`slot`](https://developer.mozilla.org/docs/Web/HTML/Element/slot) element.
+ * SlotElementProps are the props for the [`slot`](https://developer.mozilla.org/docs/Web/HTML/Element/slot) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/slot>
  */
-export interface SlotProps extends GlobalAttributes {
+export interface SlotElementProps extends GlobalAttributes {
+  /** `name` is an attribute of the [`slot`](https://developer.mozilla.org/docs/Web/HTML/Element/slot) element. */
   name?: string | undefined;
 }
 
@@ -13,6 +14,6 @@ export interface SlotProps extends GlobalAttributes {
  * slot renders the [`slot`](https://developer.mozilla.org/docs/Web/HTML/Element/slot) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/slot>
  */
-export function slot(props?: SlotProps, ...children: string[]): string {
+export function slot(props?: SlotElementProps, ...children: string[]): string {
   return renderElement("slot", props as AnyProps, false, children);
 }

--- a/small.ts
+++ b/small.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * SmallElementProps are the props for the [`small`](https://developer.mozilla.org/docs/Web/HTML/Element/small) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/small>
  */
-export type SmallElementProps = GlobalAttributes;
+export interface SmallElementProps extends GlobalAttributes {
+}
 
 /**
  * small renders the [`small`](https://developer.mozilla.org/docs/Web/HTML/Element/small) element.

--- a/small.ts
+++ b/small.ts
@@ -2,9 +2,18 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * SmallElementProps are the props for the [`small`](https://developer.mozilla.org/docs/Web/HTML/Element/small) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/small>
+ */
+export type SmallElementProps = GlobalAttributes;
+
+/**
  * small renders the [`small`](https://developer.mozilla.org/docs/Web/HTML/Element/small) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/small>
  */
-export function small(props?: GlobalAttributes, ...children: string[]): string {
+export function small(
+  props?: SmallElementProps,
+  ...children: string[]
+): string {
   return renderElement("small", props as AnyProps, false, children);
 }

--- a/source.ts
+++ b/source.ts
@@ -2,16 +2,23 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * SourceProps are the props for the [`source`](https://developer.mozilla.org/docs/Web/HTML/Element/source) element.
+ * SourceElementProps are the props for the [`source`](https://developer.mozilla.org/docs/Web/HTML/Element/source) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/source>
  */
-export interface SourceProps extends GlobalAttributes {
+export interface SourceElementProps extends GlobalAttributes {
+  /** `height` is an attribute of the [`source`](https://developer.mozilla.org/docs/Web/HTML/Element/source) element. */
   height?: string | undefined;
+  /** `media` is an attribute of the [`source`](https://developer.mozilla.org/docs/Web/HTML/Element/source) element. */
   media?: string | undefined;
+  /** `sizes` is an attribute of the [`source`](https://developer.mozilla.org/docs/Web/HTML/Element/source) element. */
   sizes?: string | undefined;
+  /** `src` is an attribute of the [`source`](https://developer.mozilla.org/docs/Web/HTML/Element/source) element. */
   src?: string | undefined;
+  /** `srcset` is an attribute of the [`source`](https://developer.mozilla.org/docs/Web/HTML/Element/source) element. */
   srcset?: string | undefined;
+  /** `type` is an attribute of the [`source`](https://developer.mozilla.org/docs/Web/HTML/Element/source) element. */
   type?: string | undefined;
+  /** `width` is an attribute of the [`source`](https://developer.mozilla.org/docs/Web/HTML/Element/source) element. */
   width?: string | undefined;
 }
 
@@ -19,6 +26,6 @@ export interface SourceProps extends GlobalAttributes {
  * source renders the [`source`](https://developer.mozilla.org/docs/Web/HTML/Element/source) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/source>
  */
-export function source(props?: SourceProps): string {
+export function source(props?: SourceElementProps): string {
   return renderElement("source", props as AnyProps, true);
 }

--- a/span.ts
+++ b/span.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * SpanElementProps are the props for the [`span`](https://developer.mozilla.org/docs/Web/HTML/Element/span) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/span>
  */
-export type SpanElementProps = GlobalAttributes;
+export interface SpanElementProps extends GlobalAttributes {
+}
 
 /**
  * span renders the [`span`](https://developer.mozilla.org/docs/Web/HTML/Element/span) element.

--- a/span.ts
+++ b/span.ts
@@ -2,9 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * SpanElementProps are the props for the [`span`](https://developer.mozilla.org/docs/Web/HTML/Element/span) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/span>
+ */
+export type SpanElementProps = GlobalAttributes;
+
+/**
  * span renders the [`span`](https://developer.mozilla.org/docs/Web/HTML/Element/span) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/span>
  */
-export function span(props?: GlobalAttributes, ...children: string[]): string {
+export function span(props?: SpanElementProps, ...children: string[]): string {
   return renderElement("span", props as AnyProps, false, children);
 }

--- a/strike.ts
+++ b/strike.ts
@@ -2,12 +2,19 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * StrikeElementProps are the props for the [`strike`](https://developer.mozilla.org/docs/Web/HTML/Element/strike) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/strike>
+ * @deprecated
+ */
+export type StrikeElementProps = GlobalAttributes;
+
+/**
  * strike renders the [`strike`](https://developer.mozilla.org/docs/Web/HTML/Element/strike) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/strike>
  * @deprecated
  */
 export function strike(
-  props?: GlobalAttributes,
+  props?: StrikeElementProps,
   ...children: string[]
 ): string {
   return renderElement("strike", props as AnyProps, false, children);

--- a/strike.ts
+++ b/strike.ts
@@ -6,7 +6,8 @@ import { renderElement } from "./lib/mod.ts";
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/strike>
  * @deprecated
  */
-export type StrikeElementProps = GlobalAttributes;
+export interface StrikeElementProps extends GlobalAttributes {
+}
 
 /**
  * strike renders the [`strike`](https://developer.mozilla.org/docs/Web/HTML/Element/strike) element.

--- a/strong.ts
+++ b/strong.ts
@@ -2,11 +2,17 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * StrongElementProps are the props for the [`strong`](https://developer.mozilla.org/docs/Web/HTML/Element/strong) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/strong>
+ */
+export type StrongElementProps = GlobalAttributes;
+
+/**
  * strong renders the [`strong`](https://developer.mozilla.org/docs/Web/HTML/Element/strong) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/strong>
  */
 export function strong(
-  props?: GlobalAttributes,
+  props?: StrongElementProps,
   ...children: string[]
 ): string {
   return renderElement("strong", props as AnyProps, false, children);

--- a/strong.ts
+++ b/strong.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * StrongElementProps are the props for the [`strong`](https://developer.mozilla.org/docs/Web/HTML/Element/strong) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/strong>
  */
-export type StrongElementProps = GlobalAttributes;
+export interface StrongElementProps extends GlobalAttributes {
+}
 
 /**
  * strong renders the [`strong`](https://developer.mozilla.org/docs/Web/HTML/Element/strong) element.

--- a/style.ts
+++ b/style.ts
@@ -2,14 +2,21 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * StyleProps are the props for the [`style`](https://developer.mozilla.org/docs/Web/HTML/Element/style) element.
+ * StyleElementProps are the props for the [`style`](https://developer.mozilla.org/docs/Web/HTML/Element/style) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/style>
  */
-export interface StyleProps extends GlobalAttributes {
-  /** @experimental */
+export interface StyleElementProps extends GlobalAttributes {
+  /**
+   * `blocking` is an attribute of the [`style`](https://developer.mozilla.org/docs/Web/HTML/Element/style) element.
+   * @experimental
+   */
   blocking?: string | undefined;
+  /** `media` is an attribute of the [`style`](https://developer.mozilla.org/docs/Web/HTML/Element/style) element. */
   media?: string | undefined;
-  /** @deprecated */
+  /**
+   * `type` is an attribute of the [`style`](https://developer.mozilla.org/docs/Web/HTML/Element/style) element.
+   * @deprecated
+   */
   type?: string | undefined;
 }
 
@@ -17,6 +24,9 @@ export interface StyleProps extends GlobalAttributes {
  * style renders the [`style`](https://developer.mozilla.org/docs/Web/HTML/Element/style) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/style>
  */
-export function style(props?: StyleProps, ...children: string[]): string {
+export function style(
+  props?: StyleElementProps,
+  ...children: string[]
+): string {
   return renderElement("style", props as AnyProps, false, children);
 }

--- a/sub.ts
+++ b/sub.ts
@@ -2,9 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * SubElementProps are the props for the [`sub`](https://developer.mozilla.org/docs/Web/HTML/Element/sub) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/sub>
+ */
+export type SubElementProps = GlobalAttributes;
+
+/**
  * sub renders the [`sub`](https://developer.mozilla.org/docs/Web/HTML/Element/sub) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/sub>
  */
-export function sub(props?: GlobalAttributes, ...children: string[]): string {
+export function sub(props?: SubElementProps, ...children: string[]): string {
   return renderElement("sub", props as AnyProps, false, children);
 }

--- a/sub.ts
+++ b/sub.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * SubElementProps are the props for the [`sub`](https://developer.mozilla.org/docs/Web/HTML/Element/sub) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/sub>
  */
-export type SubElementProps = GlobalAttributes;
+export interface SubElementProps extends GlobalAttributes {
+}
 
 /**
  * sub renders the [`sub`](https://developer.mozilla.org/docs/Web/HTML/Element/sub) element.

--- a/summary.ts
+++ b/summary.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * SummaryElementProps are the props for the [`summary`](https://developer.mozilla.org/docs/Web/HTML/Element/summary) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/summary>
  */
-export type SummaryElementProps = GlobalAttributes;
+export interface SummaryElementProps extends GlobalAttributes {
+}
 
 /**
  * summary renders the [`summary`](https://developer.mozilla.org/docs/Web/HTML/Element/summary) element.

--- a/summary.ts
+++ b/summary.ts
@@ -2,11 +2,17 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * SummaryElementProps are the props for the [`summary`](https://developer.mozilla.org/docs/Web/HTML/Element/summary) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/summary>
+ */
+export type SummaryElementProps = GlobalAttributes;
+
+/**
  * summary renders the [`summary`](https://developer.mozilla.org/docs/Web/HTML/Element/summary) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/summary>
  */
 export function summary(
-  props?: GlobalAttributes,
+  props?: SummaryElementProps,
   ...children: string[]
 ): string {
   return renderElement("summary", props as AnyProps, false, children);

--- a/sup.ts
+++ b/sup.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * SupElementProps are the props for the [`sup`](https://developer.mozilla.org/docs/Web/HTML/Element/sup) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/sup>
  */
-export type SupElementProps = GlobalAttributes;
+export interface SupElementProps extends GlobalAttributes {
+}
 
 /**
  * sup renders the [`sup`](https://developer.mozilla.org/docs/Web/HTML/Element/sup) element.

--- a/sup.ts
+++ b/sup.ts
@@ -2,9 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * SupElementProps are the props for the [`sup`](https://developer.mozilla.org/docs/Web/HTML/Element/sup) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/sup>
+ */
+export type SupElementProps = GlobalAttributes;
+
+/**
  * sup renders the [`sup`](https://developer.mozilla.org/docs/Web/HTML/Element/sup) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/sup>
  */
-export function sup(props?: GlobalAttributes, ...children: string[]): string {
+export function sup(props?: SupElementProps, ...children: string[]): string {
   return renderElement("sup", props as AnyProps, false, children);
 }

--- a/table.ts
+++ b/table.ts
@@ -2,27 +2,54 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * TableProps are the props for the [`table`](https://developer.mozilla.org/docs/Web/HTML/Element/table) element.
+ * TableElementProps are the props for the [`table`](https://developer.mozilla.org/docs/Web/HTML/Element/table) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/table>
  */
-export interface TableProps extends GlobalAttributes {
-  /** @deprecated */
+export interface TableElementProps extends GlobalAttributes {
+  /**
+   * `align` is an attribute of the [`table`](https://developer.mozilla.org/docs/Web/HTML/Element/table) element.
+   * @deprecated
+   */
   align?: string | undefined;
-  /** @deprecated */
+  /**
+   * `bgcolor` is an attribute of the [`table`](https://developer.mozilla.org/docs/Web/HTML/Element/table) element.
+   * @deprecated
+   */
   bgcolor?: string | undefined;
-  /** @deprecated */
+  /**
+   * `border` is an attribute of the [`table`](https://developer.mozilla.org/docs/Web/HTML/Element/table) element.
+   * @deprecated
+   */
   border?: string | undefined;
-  /** @deprecated */
+  /**
+   * `cellpadding` is an attribute of the [`table`](https://developer.mozilla.org/docs/Web/HTML/Element/table) element.
+   * @deprecated
+   */
   cellpadding?: string | undefined;
-  /** @deprecated */
+  /**
+   * `cellspacing` is an attribute of the [`table`](https://developer.mozilla.org/docs/Web/HTML/Element/table) element.
+   * @deprecated
+   */
   cellspacing?: string | undefined;
-  /** @deprecated */
+  /**
+   * `frame` is an attribute of the [`table`](https://developer.mozilla.org/docs/Web/HTML/Element/table) element.
+   * @deprecated
+   */
   frame?: string | undefined;
-  /** @deprecated */
+  /**
+   * `rules` is an attribute of the [`table`](https://developer.mozilla.org/docs/Web/HTML/Element/table) element.
+   * @deprecated
+   */
   rules?: string | undefined;
-  /** @deprecated */
+  /**
+   * `summary` is an attribute of the [`table`](https://developer.mozilla.org/docs/Web/HTML/Element/table) element.
+   * @deprecated
+   */
   summary?: string | undefined;
-  /** @deprecated */
+  /**
+   * `width` is an attribute of the [`table`](https://developer.mozilla.org/docs/Web/HTML/Element/table) element.
+   * @deprecated
+   */
   width?: string | undefined;
 }
 
@@ -30,6 +57,9 @@ export interface TableProps extends GlobalAttributes {
  * table renders the [`table`](https://developer.mozilla.org/docs/Web/HTML/Element/table) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/table>
  */
-export function table(props?: TableProps, ...children: string[]): string {
+export function table(
+  props?: TableElementProps,
+  ...children: string[]
+): string {
   return renderElement("table", props as AnyProps, false, children);
 }

--- a/tbody.ts
+++ b/tbody.ts
@@ -2,19 +2,34 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * TbodyProps are the props for the [`tbody`](https://developer.mozilla.org/docs/Web/HTML/Element/tbody) element.
+ * TbodyElementProps are the props for the [`tbody`](https://developer.mozilla.org/docs/Web/HTML/Element/tbody) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/tbody>
  */
-export interface TbodyProps extends GlobalAttributes {
-  /** @deprecated */
+export interface TbodyElementProps extends GlobalAttributes {
+  /**
+   * `align` is an attribute of the [`tbody`](https://developer.mozilla.org/docs/Web/HTML/Element/tbody) element.
+   * @deprecated
+   */
   align?: string | undefined;
-  /** @deprecated */
+  /**
+   * `bgcolor` is an attribute of the [`tbody`](https://developer.mozilla.org/docs/Web/HTML/Element/tbody) element.
+   * @deprecated
+   */
   bgcolor?: string | undefined;
-  /** @deprecated */
+  /**
+   * `char` is an attribute of the [`tbody`](https://developer.mozilla.org/docs/Web/HTML/Element/tbody) element.
+   * @deprecated
+   */
   char?: string | undefined;
-  /** @deprecated */
+  /**
+   * `charoff` is an attribute of the [`tbody`](https://developer.mozilla.org/docs/Web/HTML/Element/tbody) element.
+   * @deprecated
+   */
   charoff?: string | undefined;
-  /** @deprecated */
+  /**
+   * `valign` is an attribute of the [`tbody`](https://developer.mozilla.org/docs/Web/HTML/Element/tbody) element.
+   * @deprecated
+   */
   valign?: string | undefined;
 }
 
@@ -22,6 +37,9 @@ export interface TbodyProps extends GlobalAttributes {
  * tbody renders the [`tbody`](https://developer.mozilla.org/docs/Web/HTML/Element/tbody) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/tbody>
  */
-export function tbody(props?: TbodyProps, ...children: string[]): string {
+export function tbody(
+  props?: TbodyElementProps,
+  ...children: string[]
+): string {
   return renderElement("tbody", props as AnyProps, false, children);
 }

--- a/td.ts
+++ b/td.ts
@@ -2,30 +2,60 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * TdProps are the props for the [`td`](https://developer.mozilla.org/docs/Web/HTML/Element/td) element.
+ * TdElementProps are the props for the [`td`](https://developer.mozilla.org/docs/Web/HTML/Element/td) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/td>
  */
-export interface TdProps extends GlobalAttributes {
-  /** @deprecated */
+export interface TdElementProps extends GlobalAttributes {
+  /**
+   * `abbr` is an attribute of the [`td`](https://developer.mozilla.org/docs/Web/HTML/Element/td) element.
+   * @deprecated
+   */
   abbr?: string | undefined;
-  /** @deprecated */
+  /**
+   * `align` is an attribute of the [`td`](https://developer.mozilla.org/docs/Web/HTML/Element/td) element.
+   * @deprecated
+   */
   align?: string | undefined;
-  /** @deprecated */
+  /**
+   * `axis` is an attribute of the [`td`](https://developer.mozilla.org/docs/Web/HTML/Element/td) element.
+   * @deprecated
+   */
   axis?: string | undefined;
-  /** @deprecated */
+  /**
+   * `bgcolor` is an attribute of the [`td`](https://developer.mozilla.org/docs/Web/HTML/Element/td) element.
+   * @deprecated
+   */
   bgcolor?: string | undefined;
-  /** @deprecated */
+  /**
+   * `char` is an attribute of the [`td`](https://developer.mozilla.org/docs/Web/HTML/Element/td) element.
+   * @deprecated
+   */
   char?: string | undefined;
-  /** @deprecated */
+  /**
+   * `charoff` is an attribute of the [`td`](https://developer.mozilla.org/docs/Web/HTML/Element/td) element.
+   * @deprecated
+   */
   charoff?: string | undefined;
+  /** `colspan` is an attribute of the [`td`](https://developer.mozilla.org/docs/Web/HTML/Element/td) element. */
   colspan?: string | undefined;
+  /** `headers` is an attribute of the [`td`](https://developer.mozilla.org/docs/Web/HTML/Element/td) element. */
   headers?: string | undefined;
+  /** `rowspan` is an attribute of the [`td`](https://developer.mozilla.org/docs/Web/HTML/Element/td) element. */
   rowspan?: string | undefined;
-  /** @deprecated */
+  /**
+   * `scope` is an attribute of the [`td`](https://developer.mozilla.org/docs/Web/HTML/Element/td) element.
+   * @deprecated
+   */
   scope?: string | undefined;
-  /** @deprecated */
+  /**
+   * `valign` is an attribute of the [`td`](https://developer.mozilla.org/docs/Web/HTML/Element/td) element.
+   * @deprecated
+   */
   valign?: string | undefined;
-  /** @deprecated */
+  /**
+   * `width` is an attribute of the [`td`](https://developer.mozilla.org/docs/Web/HTML/Element/td) element.
+   * @deprecated
+   */
   width?: string | undefined;
 }
 
@@ -33,6 +63,6 @@ export interface TdProps extends GlobalAttributes {
  * td renders the [`td`](https://developer.mozilla.org/docs/Web/HTML/Element/td) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/td>
  */
-export function td(props?: TdProps, ...children: string[]): string {
+export function td(props?: TdElementProps, ...children: string[]): string {
   return renderElement("td", props as AnyProps, false, children);
 }

--- a/template.ts
+++ b/template.ts
@@ -2,10 +2,11 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * TemplateProps are the props for the [`template`](https://developer.mozilla.org/docs/Web/HTML/Element/template) element.
+ * TemplateElementProps are the props for the [`template`](https://developer.mozilla.org/docs/Web/HTML/Element/template) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/template>
  */
-export interface TemplateProps extends GlobalAttributes {
+export interface TemplateElementProps extends GlobalAttributes {
+  /** `shadowrootmode` is an attribute of the [`template`](https://developer.mozilla.org/docs/Web/HTML/Element/template) element. */
   shadowrootmode?: string | undefined;
 }
 
@@ -13,6 +14,9 @@ export interface TemplateProps extends GlobalAttributes {
  * template renders the [`template`](https://developer.mozilla.org/docs/Web/HTML/Element/template) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/template>
  */
-export function template(props?: TemplateProps, ...children: string[]): string {
+export function template(
+  props?: TemplateElementProps,
+  ...children: string[]
+): string {
   return renderElement("template", props as AnyProps, false, children);
 }

--- a/textarea.ts
+++ b/textarea.ts
@@ -2,23 +2,37 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * TextareaProps are the props for the [`textarea`](https://developer.mozilla.org/docs/Web/HTML/Element/textarea) element.
+ * TextareaElementProps are the props for the [`textarea`](https://developer.mozilla.org/docs/Web/HTML/Element/textarea) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/textarea>
  */
-export interface TextareaProps extends GlobalAttributes {
+export interface TextareaElementProps extends GlobalAttributes {
+  /** `autocomplete` is an attribute of the [`textarea`](https://developer.mozilla.org/docs/Web/HTML/Element/textarea) element. */
   autocomplete?: string | undefined;
+  /** `cols` is an attribute of the [`textarea`](https://developer.mozilla.org/docs/Web/HTML/Element/textarea) element. */
   cols?: string | undefined;
+  /** `dirname` is an attribute of the [`textarea`](https://developer.mozilla.org/docs/Web/HTML/Element/textarea) element. */
   dirname?: string | undefined;
+  /** `disabled` is an attribute of the [`textarea`](https://developer.mozilla.org/docs/Web/HTML/Element/textarea) element. */
   disabled?: string | undefined;
+  /** `form` is an attribute of the [`textarea`](https://developer.mozilla.org/docs/Web/HTML/Element/textarea) element. */
   form?: string | undefined;
+  /** `maxlength` is an attribute of the [`textarea`](https://developer.mozilla.org/docs/Web/HTML/Element/textarea) element. */
   maxlength?: string | undefined;
+  /** `minlength` is an attribute of the [`textarea`](https://developer.mozilla.org/docs/Web/HTML/Element/textarea) element. */
   minlength?: string | undefined;
+  /** `name` is an attribute of the [`textarea`](https://developer.mozilla.org/docs/Web/HTML/Element/textarea) element. */
   name?: string | undefined;
+  /** `placeholder` is an attribute of the [`textarea`](https://developer.mozilla.org/docs/Web/HTML/Element/textarea) element. */
   placeholder?: string | undefined;
+  /** `readonly` is an attribute of the [`textarea`](https://developer.mozilla.org/docs/Web/HTML/Element/textarea) element. */
   readonly?: string | undefined;
+  /** `required` is an attribute of the [`textarea`](https://developer.mozilla.org/docs/Web/HTML/Element/textarea) element. */
   required?: string | undefined;
+  /** `rows` is an attribute of the [`textarea`](https://developer.mozilla.org/docs/Web/HTML/Element/textarea) element. */
   rows?: string | undefined;
+  /** `spellcheck` is an attribute of the [`textarea`](https://developer.mozilla.org/docs/Web/HTML/Element/textarea) element. */
   spellcheck?: string | undefined;
+  /** `wrap` is an attribute of the [`textarea`](https://developer.mozilla.org/docs/Web/HTML/Element/textarea) element. */
   wrap?: string | undefined;
 }
 
@@ -26,6 +40,9 @@ export interface TextareaProps extends GlobalAttributes {
  * textarea renders the [`textarea`](https://developer.mozilla.org/docs/Web/HTML/Element/textarea) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/textarea>
  */
-export function textarea(props?: TextareaProps, ...children: string[]): string {
+export function textarea(
+  props?: TextareaElementProps,
+  ...children: string[]
+): string {
   return renderElement("textarea", props as AnyProps, false, children);
 }

--- a/tfoot.ts
+++ b/tfoot.ts
@@ -2,19 +2,34 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * TfootProps are the props for the [`tfoot`](https://developer.mozilla.org/docs/Web/HTML/Element/tfoot) element.
+ * TfootElementProps are the props for the [`tfoot`](https://developer.mozilla.org/docs/Web/HTML/Element/tfoot) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/tfoot>
  */
-export interface TfootProps extends GlobalAttributes {
-  /** @deprecated */
+export interface TfootElementProps extends GlobalAttributes {
+  /**
+   * `align` is an attribute of the [`tfoot`](https://developer.mozilla.org/docs/Web/HTML/Element/tfoot) element.
+   * @deprecated
+   */
   align?: string | undefined;
-  /** @deprecated */
+  /**
+   * `bgcolor` is an attribute of the [`tfoot`](https://developer.mozilla.org/docs/Web/HTML/Element/tfoot) element.
+   * @deprecated
+   */
   bgcolor?: string | undefined;
-  /** @deprecated */
+  /**
+   * `char` is an attribute of the [`tfoot`](https://developer.mozilla.org/docs/Web/HTML/Element/tfoot) element.
+   * @deprecated
+   */
   char?: string | undefined;
-  /** @deprecated */
+  /**
+   * `charoff` is an attribute of the [`tfoot`](https://developer.mozilla.org/docs/Web/HTML/Element/tfoot) element.
+   * @deprecated
+   */
   charoff?: string | undefined;
-  /** @deprecated */
+  /**
+   * `valign` is an attribute of the [`tfoot`](https://developer.mozilla.org/docs/Web/HTML/Element/tfoot) element.
+   * @deprecated
+   */
   valign?: string | undefined;
 }
 
@@ -22,6 +37,9 @@ export interface TfootProps extends GlobalAttributes {
  * tfoot renders the [`tfoot`](https://developer.mozilla.org/docs/Web/HTML/Element/tfoot) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/tfoot>
  */
-export function tfoot(props?: TfootProps, ...children: string[]): string {
+export function tfoot(
+  props?: TfootElementProps,
+  ...children: string[]
+): string {
   return renderElement("tfoot", props as AnyProps, false, children);
 }

--- a/th.ts
+++ b/th.ts
@@ -2,28 +2,54 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * ThProps are the props for the [`th`](https://developer.mozilla.org/docs/Web/HTML/Element/th) element.
+ * ThElementProps are the props for the [`th`](https://developer.mozilla.org/docs/Web/HTML/Element/th) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/th>
  */
-export interface ThProps extends GlobalAttributes {
+export interface ThElementProps extends GlobalAttributes {
+  /** `abbr` is an attribute of the [`th`](https://developer.mozilla.org/docs/Web/HTML/Element/th) element. */
   abbr?: string | undefined;
-  /** @deprecated */
+  /**
+   * `align` is an attribute of the [`th`](https://developer.mozilla.org/docs/Web/HTML/Element/th) element.
+   * @deprecated
+   */
   align?: string | undefined;
-  /** @deprecated */
+  /**
+   * `axis` is an attribute of the [`th`](https://developer.mozilla.org/docs/Web/HTML/Element/th) element.
+   * @deprecated
+   */
   axis?: string | undefined;
-  /** @deprecated */
+  /**
+   * `bgcolor` is an attribute of the [`th`](https://developer.mozilla.org/docs/Web/HTML/Element/th) element.
+   * @deprecated
+   */
   bgcolor?: string | undefined;
-  /** @deprecated */
+  /**
+   * `char` is an attribute of the [`th`](https://developer.mozilla.org/docs/Web/HTML/Element/th) element.
+   * @deprecated
+   */
   char?: string | undefined;
-  /** @deprecated */
+  /**
+   * `charoff` is an attribute of the [`th`](https://developer.mozilla.org/docs/Web/HTML/Element/th) element.
+   * @deprecated
+   */
   charoff?: string | undefined;
+  /** `colspan` is an attribute of the [`th`](https://developer.mozilla.org/docs/Web/HTML/Element/th) element. */
   colspan?: string | undefined;
+  /** `headers` is an attribute of the [`th`](https://developer.mozilla.org/docs/Web/HTML/Element/th) element. */
   headers?: string | undefined;
+  /** `rowspan` is an attribute of the [`th`](https://developer.mozilla.org/docs/Web/HTML/Element/th) element. */
   rowspan?: string | undefined;
+  /** `scope` is an attribute of the [`th`](https://developer.mozilla.org/docs/Web/HTML/Element/th) element. */
   scope?: string | undefined;
-  /** @deprecated */
+  /**
+   * `valign` is an attribute of the [`th`](https://developer.mozilla.org/docs/Web/HTML/Element/th) element.
+   * @deprecated
+   */
   valign?: string | undefined;
-  /** @deprecated */
+  /**
+   * `width` is an attribute of the [`th`](https://developer.mozilla.org/docs/Web/HTML/Element/th) element.
+   * @deprecated
+   */
   width?: string | undefined;
 }
 
@@ -31,6 +57,6 @@ export interface ThProps extends GlobalAttributes {
  * th renders the [`th`](https://developer.mozilla.org/docs/Web/HTML/Element/th) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/th>
  */
-export function th(props?: ThProps, ...children: string[]): string {
+export function th(props?: ThElementProps, ...children: string[]): string {
   return renderElement("th", props as AnyProps, false, children);
 }

--- a/thead.ts
+++ b/thead.ts
@@ -2,19 +2,34 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * TheadProps are the props for the [`thead`](https://developer.mozilla.org/docs/Web/HTML/Element/thead) element.
+ * TheadElementProps are the props for the [`thead`](https://developer.mozilla.org/docs/Web/HTML/Element/thead) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/thead>
  */
-export interface TheadProps extends GlobalAttributes {
-  /** @deprecated */
+export interface TheadElementProps extends GlobalAttributes {
+  /**
+   * `align` is an attribute of the [`thead`](https://developer.mozilla.org/docs/Web/HTML/Element/thead) element.
+   * @deprecated
+   */
   align?: string | undefined;
-  /** @deprecated */
+  /**
+   * `bgcolor` is an attribute of the [`thead`](https://developer.mozilla.org/docs/Web/HTML/Element/thead) element.
+   * @deprecated
+   */
   bgcolor?: string | undefined;
-  /** @deprecated */
+  /**
+   * `char` is an attribute of the [`thead`](https://developer.mozilla.org/docs/Web/HTML/Element/thead) element.
+   * @deprecated
+   */
   char?: string | undefined;
-  /** @deprecated */
+  /**
+   * `charoff` is an attribute of the [`thead`](https://developer.mozilla.org/docs/Web/HTML/Element/thead) element.
+   * @deprecated
+   */
   charoff?: string | undefined;
-  /** @deprecated */
+  /**
+   * `valign` is an attribute of the [`thead`](https://developer.mozilla.org/docs/Web/HTML/Element/thead) element.
+   * @deprecated
+   */
   valign?: string | undefined;
 }
 
@@ -22,6 +37,9 @@ export interface TheadProps extends GlobalAttributes {
  * thead renders the [`thead`](https://developer.mozilla.org/docs/Web/HTML/Element/thead) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/thead>
  */
-export function thead(props?: TheadProps, ...children: string[]): string {
+export function thead(
+  props?: TheadElementProps,
+  ...children: string[]
+): string {
   return renderElement("thead", props as AnyProps, false, children);
 }

--- a/time.ts
+++ b/time.ts
@@ -2,10 +2,11 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * TimeProps are the props for the [`time`](https://developer.mozilla.org/docs/Web/HTML/Element/time) element.
+ * TimeElementProps are the props for the [`time`](https://developer.mozilla.org/docs/Web/HTML/Element/time) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/time>
  */
-export interface TimeProps extends GlobalAttributes {
+export interface TimeElementProps extends GlobalAttributes {
+  /** `datetime` is an attribute of the [`time`](https://developer.mozilla.org/docs/Web/HTML/Element/time) element. */
   datetime?: string | undefined;
 }
 
@@ -13,6 +14,6 @@ export interface TimeProps extends GlobalAttributes {
  * time renders the [`time`](https://developer.mozilla.org/docs/Web/HTML/Element/time) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/time>
  */
-export function time(props?: TimeProps, ...children: string[]): string {
+export function time(props?: TimeElementProps, ...children: string[]): string {
   return renderElement("time", props as AnyProps, false, children);
 }

--- a/title.ts
+++ b/title.ts
@@ -2,9 +2,18 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * TitleElementProps are the props for the [`title`](https://developer.mozilla.org/docs/Web/HTML/Element/title) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/title>
+ */
+export type TitleElementProps = GlobalAttributes;
+
+/**
  * title renders the [`title`](https://developer.mozilla.org/docs/Web/HTML/Element/title) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/title>
  */
-export function title(props?: GlobalAttributes, ...children: string[]): string {
+export function title(
+  props?: TitleElementProps,
+  ...children: string[]
+): string {
   return renderElement("title", props as AnyProps, false, children);
 }

--- a/title.ts
+++ b/title.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * TitleElementProps are the props for the [`title`](https://developer.mozilla.org/docs/Web/HTML/Element/title) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/title>
  */
-export type TitleElementProps = GlobalAttributes;
+export interface TitleElementProps extends GlobalAttributes {
+}
 
 /**
  * title renders the [`title`](https://developer.mozilla.org/docs/Web/HTML/Element/title) element.

--- a/tr.ts
+++ b/tr.ts
@@ -2,19 +2,34 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * TrProps are the props for the [`tr`](https://developer.mozilla.org/docs/Web/HTML/Element/tr) element.
+ * TrElementProps are the props for the [`tr`](https://developer.mozilla.org/docs/Web/HTML/Element/tr) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/tr>
  */
-export interface TrProps extends GlobalAttributes {
-  /** @deprecated */
+export interface TrElementProps extends GlobalAttributes {
+  /**
+   * `align` is an attribute of the [`tr`](https://developer.mozilla.org/docs/Web/HTML/Element/tr) element.
+   * @deprecated
+   */
   align?: string | undefined;
-  /** @deprecated */
+  /**
+   * `bgcolor` is an attribute of the [`tr`](https://developer.mozilla.org/docs/Web/HTML/Element/tr) element.
+   * @deprecated
+   */
   bgcolor?: string | undefined;
-  /** @deprecated */
+  /**
+   * `char` is an attribute of the [`tr`](https://developer.mozilla.org/docs/Web/HTML/Element/tr) element.
+   * @deprecated
+   */
   char?: string | undefined;
-  /** @deprecated */
+  /**
+   * `charoff` is an attribute of the [`tr`](https://developer.mozilla.org/docs/Web/HTML/Element/tr) element.
+   * @deprecated
+   */
   charoff?: string | undefined;
-  /** @deprecated */
+  /**
+   * `valign` is an attribute of the [`tr`](https://developer.mozilla.org/docs/Web/HTML/Element/tr) element.
+   * @deprecated
+   */
   valign?: string | undefined;
 }
 
@@ -22,6 +37,6 @@ export interface TrProps extends GlobalAttributes {
  * tr renders the [`tr`](https://developer.mozilla.org/docs/Web/HTML/Element/tr) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/tr>
  */
-export function tr(props?: TrProps, ...children: string[]): string {
+export function tr(props?: TrElementProps, ...children: string[]): string {
   return renderElement("tr", props as AnyProps, false, children);
 }

--- a/track.ts
+++ b/track.ts
@@ -2,14 +2,19 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * TrackProps are the props for the [`track`](https://developer.mozilla.org/docs/Web/HTML/Element/track) element.
+ * TrackElementProps are the props for the [`track`](https://developer.mozilla.org/docs/Web/HTML/Element/track) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/track>
  */
-export interface TrackProps extends GlobalAttributes {
+export interface TrackElementProps extends GlobalAttributes {
+  /** `default` is an attribute of the [`track`](https://developer.mozilla.org/docs/Web/HTML/Element/track) element. */
   default?: string | undefined;
+  /** `kind` is an attribute of the [`track`](https://developer.mozilla.org/docs/Web/HTML/Element/track) element. */
   kind?: string | undefined;
+  /** `label` is an attribute of the [`track`](https://developer.mozilla.org/docs/Web/HTML/Element/track) element. */
   label?: string | undefined;
+  /** `src` is an attribute of the [`track`](https://developer.mozilla.org/docs/Web/HTML/Element/track) element. */
   src?: string | undefined;
+  /** `srclang` is an attribute of the [`track`](https://developer.mozilla.org/docs/Web/HTML/Element/track) element. */
   srclang?: string | undefined;
 }
 
@@ -17,6 +22,6 @@ export interface TrackProps extends GlobalAttributes {
  * track renders the [`track`](https://developer.mozilla.org/docs/Web/HTML/Element/track) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/track>
  */
-export function track(props?: TrackProps): string {
+export function track(props?: TrackElementProps): string {
   return renderElement("track", props as AnyProps, true);
 }

--- a/tt.ts
+++ b/tt.ts
@@ -6,7 +6,8 @@ import { renderElement } from "./lib/mod.ts";
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/tt>
  * @deprecated
  */
-export type TtElementProps = GlobalAttributes;
+export interface TtElementProps extends GlobalAttributes {
+}
 
 /**
  * tt renders the [`tt`](https://developer.mozilla.org/docs/Web/HTML/Element/tt) element.

--- a/tt.ts
+++ b/tt.ts
@@ -2,10 +2,17 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * TtElementProps are the props for the [`tt`](https://developer.mozilla.org/docs/Web/HTML/Element/tt) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/tt>
+ * @deprecated
+ */
+export type TtElementProps = GlobalAttributes;
+
+/**
  * tt renders the [`tt`](https://developer.mozilla.org/docs/Web/HTML/Element/tt) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/tt>
  * @deprecated
  */
-export function tt(props?: GlobalAttributes, ...children: string[]): string {
+export function tt(props?: TtElementProps, ...children: string[]): string {
   return renderElement("tt", props as AnyProps, false, children);
 }

--- a/u.ts
+++ b/u.ts
@@ -2,9 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * UElementProps are the props for the [`u`](https://developer.mozilla.org/docs/Web/HTML/Element/u) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/u>
+ */
+export type UElementProps = GlobalAttributes;
+
+/**
  * u renders the [`u`](https://developer.mozilla.org/docs/Web/HTML/Element/u) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/u>
  */
-export function u(props?: GlobalAttributes, ...children: string[]): string {
+export function u(props?: UElementProps, ...children: string[]): string {
   return renderElement("u", props as AnyProps, false, children);
 }

--- a/u.ts
+++ b/u.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * UElementProps are the props for the [`u`](https://developer.mozilla.org/docs/Web/HTML/Element/u) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/u>
  */
-export type UElementProps = GlobalAttributes;
+export interface UElementProps extends GlobalAttributes {
+}
 
 /**
  * u renders the [`u`](https://developer.mozilla.org/docs/Web/HTML/Element/u) element.

--- a/ul.ts
+++ b/ul.ts
@@ -2,13 +2,19 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * UlProps are the props for the [`ul`](https://developer.mozilla.org/docs/Web/HTML/Element/ul) element.
+ * UlElementProps are the props for the [`ul`](https://developer.mozilla.org/docs/Web/HTML/Element/ul) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/ul>
  */
-export interface UlProps extends GlobalAttributes {
-  /** @deprecated */
+export interface UlElementProps extends GlobalAttributes {
+  /**
+   * `compact` is an attribute of the [`ul`](https://developer.mozilla.org/docs/Web/HTML/Element/ul) element.
+   * @deprecated
+   */
   compact?: string | undefined;
-  /** @deprecated */
+  /**
+   * `type` is an attribute of the [`ul`](https://developer.mozilla.org/docs/Web/HTML/Element/ul) element.
+   * @deprecated
+   */
   type?: string | undefined;
 }
 
@@ -16,6 +22,6 @@ export interface UlProps extends GlobalAttributes {
  * ul renders the [`ul`](https://developer.mozilla.org/docs/Web/HTML/Element/ul) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/ul>
  */
-export function ul(props?: UlProps, ...children: string[]): string {
+export function ul(props?: UlElementProps, ...children: string[]): string {
   return renderElement("ul", props as AnyProps, false, children);
 }

--- a/var.ts
+++ b/var.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * VarElementProps are the props for the [`var`](https://developer.mozilla.org/docs/Web/HTML/Element/var) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/var>
  */
-export type VarElementProps = GlobalAttributes;
+export interface VarElementProps extends GlobalAttributes {
+}
 
 /**
  * var_ renders the [`var`](https://developer.mozilla.org/docs/Web/HTML/Element/var) element.

--- a/var.ts
+++ b/var.ts
@@ -2,9 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * VarElementProps are the props for the [`var`](https://developer.mozilla.org/docs/Web/HTML/Element/var) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/var>
+ */
+export type VarElementProps = GlobalAttributes;
+
+/**
  * var_ renders the [`var`](https://developer.mozilla.org/docs/Web/HTML/Element/var) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/var>
  */
-export function var_(props?: GlobalAttributes, ...children: string[]): string {
+export function var_(props?: VarElementProps, ...children: string[]): string {
   return renderElement("var", props as AnyProps, false, children);
 }

--- a/video.ts
+++ b/video.ts
@@ -2,23 +2,37 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
- * VideoProps are the props for the [`video`](https://developer.mozilla.org/docs/Web/HTML/Element/video) element.
+ * VideoElementProps are the props for the [`video`](https://developer.mozilla.org/docs/Web/HTML/Element/video) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/video>
  */
-export interface VideoProps extends GlobalAttributes {
+export interface VideoElementProps extends GlobalAttributes {
+  /** `autoplay` is an attribute of the [`video`](https://developer.mozilla.org/docs/Web/HTML/Element/video) element. */
   autoplay?: string | undefined;
+  /** `controls` is an attribute of the [`video`](https://developer.mozilla.org/docs/Web/HTML/Element/video) element. */
   controls?: string | undefined;
+  /** `controlslist` is an attribute of the [`video`](https://developer.mozilla.org/docs/Web/HTML/Element/video) element. */
   controlslist?: string | undefined;
+  /** `crossorigin` is an attribute of the [`video`](https://developer.mozilla.org/docs/Web/HTML/Element/video) element. */
   crossorigin?: string | undefined;
+  /** `disablepictureinpicture` is an attribute of the [`video`](https://developer.mozilla.org/docs/Web/HTML/Element/video) element. */
   disablepictureinpicture?: string | undefined;
+  /** `disableremoteplayback` is an attribute of the [`video`](https://developer.mozilla.org/docs/Web/HTML/Element/video) element. */
   disableremoteplayback?: string | undefined;
+  /** `height` is an attribute of the [`video`](https://developer.mozilla.org/docs/Web/HTML/Element/video) element. */
   height?: string | undefined;
+  /** `loop` is an attribute of the [`video`](https://developer.mozilla.org/docs/Web/HTML/Element/video) element. */
   loop?: string | undefined;
+  /** `muted` is an attribute of the [`video`](https://developer.mozilla.org/docs/Web/HTML/Element/video) element. */
   muted?: string | undefined;
+  /** `playsinline` is an attribute of the [`video`](https://developer.mozilla.org/docs/Web/HTML/Element/video) element. */
   playsinline?: string | undefined;
+  /** `poster` is an attribute of the [`video`](https://developer.mozilla.org/docs/Web/HTML/Element/video) element. */
   poster?: string | undefined;
+  /** `preload` is an attribute of the [`video`](https://developer.mozilla.org/docs/Web/HTML/Element/video) element. */
   preload?: string | undefined;
+  /** `src` is an attribute of the [`video`](https://developer.mozilla.org/docs/Web/HTML/Element/video) element. */
   src?: string | undefined;
+  /** `width` is an attribute of the [`video`](https://developer.mozilla.org/docs/Web/HTML/Element/video) element. */
   width?: string | undefined;
 }
 
@@ -26,6 +40,9 @@ export interface VideoProps extends GlobalAttributes {
  * video renders the [`video`](https://developer.mozilla.org/docs/Web/HTML/Element/video) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/video>
  */
-export function video(props?: VideoProps, ...children: string[]): string {
+export function video(
+  props?: VideoElementProps,
+  ...children: string[]
+): string {
   return renderElement("video", props as AnyProps, false, children);
 }

--- a/wbr.ts
+++ b/wbr.ts
@@ -5,7 +5,8 @@ import { renderElement } from "./lib/mod.ts";
  * WbrElementProps are the props for the [`wbr`](https://developer.mozilla.org/docs/Web/HTML/Element/wbr) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/wbr>
  */
-export type WbrElementProps = GlobalAttributes;
+export interface WbrElementProps extends GlobalAttributes {
+}
 
 /**
  * wbr renders the [`wbr`](https://developer.mozilla.org/docs/Web/HTML/Element/wbr) element.

--- a/wbr.ts
+++ b/wbr.ts
@@ -2,9 +2,15 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * WbrElementProps are the props for the [`wbr`](https://developer.mozilla.org/docs/Web/HTML/Element/wbr) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/wbr>
+ */
+export type WbrElementProps = GlobalAttributes;
+
+/**
  * wbr renders the [`wbr`](https://developer.mozilla.org/docs/Web/HTML/Element/wbr) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/wbr>
  */
-export function wbr(props?: GlobalAttributes): string {
+export function wbr(props?: WbrElementProps): string {
   return renderElement("wbr", props as AnyProps, true);
 }

--- a/xmp.ts
+++ b/xmp.ts
@@ -6,7 +6,8 @@ import { renderElement } from "./lib/mod.ts";
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/xmp>
  * @deprecated
  */
-export type XmpElementProps = GlobalAttributes;
+export interface XmpElementProps extends GlobalAttributes {
+}
 
 /**
  * xmp renders the [`xmp`](https://developer.mozilla.org/docs/Web/HTML/Element/xmp) element.

--- a/xmp.ts
+++ b/xmp.ts
@@ -2,10 +2,17 @@ import type { AnyProps, GlobalAttributes } from "./lib/mod.ts";
 import { renderElement } from "./lib/mod.ts";
 
 /**
+ * XmpElementProps are the props for the [`xmp`](https://developer.mozilla.org/docs/Web/HTML/Element/xmp) element.
+ * @see <https://developer.mozilla.org/docs/Web/HTML/Element/xmp>
+ * @deprecated
+ */
+export type XmpElementProps = GlobalAttributes;
+
+/**
  * xmp renders the [`xmp`](https://developer.mozilla.org/docs/Web/HTML/Element/xmp) element.
  * @see <https://developer.mozilla.org/docs/Web/HTML/Element/xmp>
  * @deprecated
  */
-export function xmp(props?: GlobalAttributes, ...children: string[]): string {
+export function xmp(props?: XmpElementProps, ...children: string[]): string {
   return renderElement("xmp", props as AnyProps, false, children);
 }


### PR DESCRIPTION
### Overview

Currently, some element render functions directly use the `GlobalAttributes` type as their props. Instead, we should still create an interface that extends `GlobalAttributes` with empty parameters. This allows library users to predict the element props interface name of an element render function.